### PR TITLE
feat: reduce alloc when parsing large objects and arrays

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -97,26 +97,55 @@ func (p *Parser) ParseBytesWithoutCache(b []byte) (*Value, error) {
 
 type cache struct {
 	vs []Value
+	nx *cache // next
+	lt *cache // last
 }
 
 func (c *cache) reset() {
 	c.vs = c.vs[:0]
+	c.lt = nil
+	if c.nx != nil {
+		c.nx.reset()
+	}
 }
+
+const (
+	preAllocatedCacheSize = 341   // 32kb class size
+	maxAllocatedCacheSize = 10922 // 1MB
+)
 
 func (c *cache) getValue() *Value {
 	if c == nil {
 		return &Value{}
 	}
-	if cap(c.vs) > len(c.vs) {
-		c.vs = c.vs[:len(c.vs)+1]
-	} else {
-		if len(c.vs) == 0 {
-			c.vs = make([]Value, 4)
-		} else {
-			c.vs = make([]Value, 1, len(c.vs)*2)
-		}
+	readSrc := c
+	if readSrc.lt != nil {
+		readSrc = readSrc.lt
 	}
-	return &c.vs[len(c.vs)-1]
+	switch {
+	case cap(readSrc.vs) == 0:
+		// initial state
+		readSrc.vs = make([]Value, 1, preAllocatedCacheSize)
+
+	case cap(readSrc.vs) > len(readSrc.vs):
+		readSrc.vs = readSrc.vs[:len(readSrc.vs)+1]
+
+	default:
+		if readSrc.nx == nil {
+			nextLen := len(readSrc.vs) * 2
+			if nextLen > maxAllocatedCacheSize {
+				nextLen = maxAllocatedCacheSize
+			}
+			readSrc.nx = &cache{
+				vs: make([]Value, 0, nextLen),
+			}
+		}
+		c.lt = readSrc.nx
+		readSrc = readSrc.nx
+		readSrc.vs = readSrc.vs[:len(readSrc.vs)+1]
+	}
+	// Do not reset the value, since the caller must properly init it.
+	return &readSrc.vs[len(readSrc.vs)-1]
 }
 
 func skipWS(s string) string {
@@ -540,29 +569,41 @@ func parseRawNumber(s string) (string, string, error) {
 type Object struct {
 	kvs           []kv
 	keysUnescaped bool
+	nx            *Object
+	lt            *Object
 }
 
 func (o *Object) reset() {
 	o.kvs = o.kvs[:0]
 	o.keysUnescaped = false
+	o.lt = nil
+	if o.nx != nil {
+		o.nx.reset()
+	}
 }
 
 // MarshalTo appends marshaled o to dst and returns the result.
 func (o *Object) MarshalTo(dst []byte) []byte {
 	dst = append(dst, '{')
-	for i, kv := range o.kvs {
-		if o.keysUnescaped {
-			dst = escapeString(dst, kv.k)
-		} else {
-			dst = append(dst, '"')
-			dst = append(dst, kv.k...)
-			dst = append(dst, '"')
+	srcKV := o
+	lastN := o.Len()
+	n := 0
+	for srcKV != nil {
+		for _, kv := range srcKV.kvs {
+			if srcKV.keysUnescaped {
+				dst = escapeString(dst, kv.k)
+			} else {
+				dst = append(dst, '"')
+				dst = append(dst, kv.k...)
+				dst = append(dst, '"')
+			}
+			dst = append(dst, ':')
+			dst = kv.v.MarshalTo(dst)
+			if n++; n != lastN {
+				dst = append(dst, ',')
+			}
 		}
-		dst = append(dst, ':')
-		dst = kv.v.MarshalTo(dst)
-		if i != len(o.kvs)-1 {
-			dst = append(dst, ',')
-		}
+		srcKV = srcKV.nx
 	}
 	dst = append(dst, '}')
 	return dst
@@ -579,13 +620,45 @@ func (o *Object) String() string {
 	return b2s(b)
 }
 
+const (
+	preAllocatedObjectKVs = 170   // 8kb class
+	maxAllocatedObjectKVS = 21845 // 1MB class
+)
+
 func (o *Object) getKV() *kv {
-	if cap(o.kvs) > len(o.kvs) {
-		o.kvs = o.kvs[:len(o.kvs)+1]
-	} else {
-		o.kvs = append(o.kvs, kv{})
+	kvSrc := o
+	if kvSrc.lt != nil {
+		kvSrc = kvSrc.lt
 	}
-	return &o.kvs[len(o.kvs)-1]
+	switch {
+	case cap(kvSrc.kvs) == 0:
+		// initial state
+		kvSrc.kvs = append(kvSrc.kvs, kv{})
+
+	case cap(kvSrc.kvs) > len(kvSrc.kvs):
+		kvSrc.kvs = kvSrc.kvs[:len(kvSrc.kvs)+1]
+
+	default:
+		if cap(kvSrc.kvs) < preAllocatedObjectKVs {
+			kvSrc.kvs = append(kvSrc.kvs, kv{})
+			break
+		}
+		// new chain
+		if kvSrc.nx == nil {
+			nextLen := len(kvSrc.kvs) * 2
+			if nextLen > maxAllocatedObjectKVS {
+				nextLen = maxAllocatedObjectKVS
+			}
+			kvSrc.nx = &Object{
+				kvs: make([]kv, 0, nextLen),
+			}
+		}
+		kvSrc = kvSrc.nx
+		o.lt = kvSrc
+		kvSrc.kvs = kvSrc.kvs[:len(kvSrc.kvs)+1]
+	}
+
+	return &kvSrc.kvs[len(kvSrc.kvs)-1]
 }
 
 func (o *Object) unescapeKeys() {
@@ -597,12 +670,18 @@ func (o *Object) unescapeKeys() {
 		kv := &kvs[i]
 		kv.k = unescapeStringBestEffort(kv.k)
 	}
+	if o.nx != nil {
+		o.nx.unescapeKeys()
+	}
 	o.keysUnescaped = true
 }
 
 // Len returns the number of items in the o.
 func (o *Object) Len() int {
-	return len(o.kvs)
+	if o.nx == nil {
+		return len(o.kvs)
+	}
+	return len(o.kvs) + o.nx.Len()
 }
 
 // Get returns the value for the given key in the o.
@@ -618,6 +697,11 @@ func (o *Object) Get(key string) *Value {
 				return kv.v
 			}
 		}
+		if o.nx != nil {
+			if v := o.nx.Get(key); v != nil {
+				return v
+			}
+		}
 	}
 
 	// Slow path - unescape object keys.
@@ -628,6 +712,13 @@ func (o *Object) Get(key string) *Value {
 			return kv.v
 		}
 	}
+
+	if o.nx != nil {
+		if v := o.nx.Get(key); v != nil {
+			return v
+		}
+	}
+
 	return nil
 }
 
@@ -644,6 +735,10 @@ func (o *Object) Visit(f func(key []byte, v *Value)) {
 
 	for _, kv := range o.kvs {
 		f(s2b(kv.k), kv.v)
+	}
+
+	if o.nx != nil {
+		o.nx.Visit(f)
 	}
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1288,3 +1288,27 @@ func TestParseWithoutCache(t *testing.T) {
 		t.Fatalf("unexpected value for key=%q; got %q; want %q", "foo", sb, "bar")
 	}
 }
+
+func TestMarshalTo(t *testing.T) {
+	fileData := getFromFile("testdata/bunchFields.json")
+	var p Parser
+	v, err := p.Parse(fileData)
+	if err != nil {
+		t.Fatalf("cannot parse json: %s", err)
+	}
+	data := make([]byte, 0, len(fileData))
+	data = v.MarshalTo(data)
+	// check
+	var p2 Parser
+	v, err = p2.ParseBytes(data)
+	if err != nil {
+		t.Fatalf("cannot parse json: %s", err)
+	}
+	o, err := v.Object()
+	if err != nil {
+		t.Fatalf("expected object, got: %s", o.String())
+	}
+	if o.Len() != 871 {
+		t.Fatalf("expected 871 fields, got %d", o.Len())
+	}
+}

--- a/testdata/bunchFields.json
+++ b/testdata/bunchFields.json
@@ -1,0 +1,1984 @@
+{
+    "4": null,
+    "33": 8.827415335666956,
+    "34": null,
+    "60": 1544,
+    "66": 81.45354629370038,
+    "71": null,
+    "77": {
+        "only": 1986,
+        "band": {},
+        "clearly": 589
+    },
+    "80": false,
+    "87": null,
+    "106": 26.34147621235201,
+    "181": 307,
+    "202": "drew lovely shallow save few",
+    "206": false,
+    "216": [
+        "leaf",
+        "shallow",
+        "school",
+        "jungle",
+        "victory",
+        "fastened"
+    ],
+    "224": null,
+    "237": true,
+    "244": 87.0159461408396,
+    "261": 1579,
+    "306": [
+        4221,
+        733
+    ],
+    "344": "sunlight",
+    "360": 442,
+    "363": [
+        "settle",
+        "saddle",
+        "job",
+        "wonder",
+        "thing",
+        "old"
+    ],
+    "380": 1852,
+    "391": null,
+    "395": "industrial alphabet everything bone balloon",
+    "411": 748,
+    "412": {
+        "discovery": null,
+        "traffic": 1509
+    },
+    "434": null,
+    "443": 38.614679983063496,
+    "454": "damage bill mysterious zoo lack",
+    "460": false,
+    "470": null,
+    "472": 25.366366418271014,
+    "506": 24.30011559608849,
+    "515": "important valley",
+    "518": 51.56417962641064,
+    "529": {},
+    "558": {
+        "test": "shelf jump flies fill"
+    },
+    "564": true,
+    "570": "soil",
+    "592": "grew track rubber talk",
+    "642": [
+        2824,
+        1531,
+        1138
+    ],
+    "649": "family friendly original consonant label",
+    "661": [
+        "diagram",
+        "bee",
+        "weather",
+        "manner",
+        "college",
+        "left"
+    ],
+    "679": [
+        "list",
+        "send",
+        "observe"
+    ],
+    "689": false,
+    "697": {
+        "anything": null
+    },
+    "703": false,
+    "704": false,
+    "751": null,
+    "760": "die simply",
+    "769": 28.468149101906537,
+    "807": null,
+    "809": [
+        "space",
+        "bit"
+    ],
+    "815": "must produce struck",
+    "818": 74.11701302777114,
+    "827": {
+        "magic": [
+            "fire",
+            "art"
+        ],
+        "position": [
+            109,
+            576,
+            1877
+        ]
+    },
+    "838": false,
+    "851": 88.86769889791624,
+    "890": 1216,
+    "898": false,
+    "899": true,
+    "923": {
+        "trouble": [
+            3136,
+            1402,
+            2967,
+            4985
+        ]
+    },
+    "933": true,
+    "934": 49.09026007082997,
+    "940": false,
+    "996": 67.49659332410609,
+    "1011": 25.36735978339244,
+    "1022": "realize women statement",
+    "1029": "trade living",
+    "1051": "past do language variety",
+    "1053": 30.01522380371493,
+    "1056": 1967,
+    "1071": 1056,
+    "1078": 71.70993910805974,
+    "1110": 50.13769289738526,
+    "1118": false,
+    "1123": [
+        "movie",
+        "low",
+        "thick",
+        "thing"
+    ],
+    "1129": true,
+    "1130": true,
+    "1149": 1103,
+    "1162": 17.470981644030136,
+    "1170": [
+        "race",
+        "onto",
+        "difference",
+        "nature",
+        "basic",
+        "east"
+    ],
+    "1185": 22.292555485359845,
+    "1186": "battle pretty school",
+    "1201": "strip managed wish eager",
+    "1221": "instance be third",
+    "1241": false,
+    "1249": [
+        "mill",
+        "slow",
+        "stepped"
+    ],
+    "1252": null,
+    "1280": null,
+    "1283": "parts spell science border",
+    "1296": null,
+    "1299": 858,
+    "1300": {
+        "research": 1039,
+        "iron": true,
+        "capital": 1726
+    },
+    "1310": [
+        "control",
+        "thank"
+    ],
+    "1330": 89.92519099371965,
+    "1343": 68.93906037407673,
+    "1367": null,
+    "1373": {
+        "though": "strong kind see"
+    },
+    "1381": 746,
+    "1384": true,
+    "1385": "left thou pound",
+    "1386": 17,
+    "1393": "sound",
+    "1396": 66.3338843696008,
+    "1412": "another account necessary",
+    "1435": null,
+    "1455": true,
+    "1472": [
+        10,
+        3594,
+        2207
+    ],
+    "1486": "plural seed",
+    "1510": [
+        "baby",
+        "while",
+        "ship"
+    ],
+    "1577": "camera swung garden",
+    "1579": false,
+    "1606": 90.63675627257606,
+    "1629": [
+        "variety",
+        "carried",
+        "rock",
+        "cat",
+        "reader",
+        "friend"
+    ],
+    "1642": null,
+    "1647": [
+        "daily",
+        "careful",
+        "that",
+        "was"
+    ],
+    "1655": "double clothing progress church",
+    "1671": {
+        "sad": "collect tin",
+        "thank": null
+    },
+    "1699": 546,
+    "1722": [
+        1486,
+        3325,
+        3002
+    ],
+    "1756": "nervous",
+    "1757": null,
+    "1799": "quietly later",
+    "1812": true,
+    "1813": 39.68494782257692,
+    "1851": false,
+    "1863": null,
+    "1864": null,
+    "1888": {
+        "girl": [
+            1452,
+            453,
+            483,
+            4624,
+            2505
+        ],
+        "farther": true,
+        "relationship": null
+    },
+    "1912": 80.4438616432587,
+    "1923": false,
+    "1926": [
+        "arrange",
+        "all",
+        "date"
+    ],
+    "1938": 14,
+    "1951": 52.0701206974419,
+    "1953": "blue somehow refused",
+    "1962": true,
+    "1978": 1195,
+    "1986": null,
+    "2006": null,
+    "2082": {
+        "fix": {},
+        "breakfast": null
+    },
+    "2088": {},
+    "2093": 1431,
+    "2129": {},
+    "2137": null,
+    "2164": 14.640221893072592,
+    "2188": {},
+    "2210": 1424,
+    "2322": "atmosphere danger",
+    "2369": null,
+    "2396": {
+        "dish": true,
+        "bottle": true
+    },
+    "2399": {
+        "fort": 16.19332092657293
+    },
+    "2402": null,
+    "2415": [
+        81,
+        1459,
+        802
+    ],
+    "2438": true,
+    "2451": 1227,
+    "2452": null,
+    "2463": 49.51093194596754,
+    "2469": true,
+    "2474": {},
+    "2503": null,
+    "2524": "paper excitement trouble active customs",
+    "2534": {
+        "solution": [
+            3443,
+            1507,
+            500,
+            2515
+        ],
+        "because": null
+    },
+    "2537": null,
+    "2547": false,
+    "2551": {
+        "speech": [
+            4524,
+            2636,
+            4171,
+            2047,
+            0
+        ],
+        "ability": "symbol jet out right butter"
+    },
+    "2553": {
+        "slip": [
+            "underline",
+            "bark",
+            "railroad",
+            "somewhere",
+            "harbor",
+            "that"
+        ],
+        "forty": 33.90259029432685,
+        "hot": "also wave exact either bank"
+    },
+    "2562": 727,
+    "2580": "actual",
+    "2585": 738,
+    "2612": false,
+    "2645": 1150,
+    "2661": [
+        1821,
+        3012,
+        4398
+    ],
+    "2691": false,
+    "2698": "throughout tomorrow figure",
+    "2702": [
+        "club",
+        "brass",
+        "poet",
+        "cookies"
+    ],
+    "2741": true,
+    "2767": "river couple shallow",
+    "2774": 599,
+    "2777": {
+        "slipped": 28.72901973805004
+    },
+    "2793": [
+        "moment",
+        "frozen"
+    ],
+    "2797": "pressure driver",
+    "2802": null,
+    "2818": 824,
+    "2836": true,
+    "2846": [
+        3825,
+        1794,
+        4941
+    ],
+    "2853": {
+        "primitive": "now age attached parts"
+    },
+    "2860": null,
+    "2895": true,
+    "2910": 480,
+    "2912": 37.00094169052357,
+    "2972": "steady chair",
+    "2984": null,
+    "2997": {
+        "national": "driving lonely even",
+        "magic": {},
+        "fight": "wore opportunity noun outside beauty"
+    },
+    "proud": 36.93532489130482,
+    "too": 0,
+    "left": "food",
+    "fire": 912,
+    "primitive": {
+        "develop": null
+    },
+    "wood": [
+        "afternoon",
+        "traffic",
+        "sun",
+        "railroad",
+        "character",
+        "fifteen"
+    ],
+    "cutting": 1727,
+    "back": [
+        4180,
+        2559,
+        3805
+    ],
+    "price": 92.60541362191488,
+    "dropped": {
+        "where": 7.582205996578506,
+        "was": null,
+        "tune": null
+    },
+    "twenty": null,
+    "balance": "goose",
+    "final": {
+        "job": [
+            "instant",
+            "industrial",
+            "quietly",
+            "current"
+        ]
+    },
+    "rubbed": {
+        "finger": 1908,
+        "aside": {
+            "treated": false
+        },
+        "also": {}
+    },
+    "disappear": null,
+    "elephant": "visit rate particularly sight shaking",
+    "built": "exactly",
+    "grew": [
+        "next",
+        "mice",
+        "shirt",
+        "mill"
+    ],
+    "serve": null,
+    "environment": null,
+    "its": [
+        3730,
+        1312,
+        2061
+    ],
+    "vowel": true,
+    "sign": 1082,
+    "tune": 1410,
+    "sand": 371,
+    "treated": null,
+    "exact": null,
+    "surprise": false,
+    "setting": true,
+    "save": [
+        4846,
+        372,
+        1830
+    ],
+    "means": null,
+    "connected": {
+        "usually": null,
+        "fought": 170,
+        "plenty": [
+            1136,
+            2136
+        ]
+    },
+    "transportation": 1410,
+    "species": 1854,
+    "red": 8.453583411993936,
+    "changing": 34.10549348264218,
+    "mile": 88.62142781212754,
+    "parent": {
+        "population": [
+            "straight",
+            "broken"
+        ]
+    },
+    "bad": {},
+    "itself": null,
+    "skill": null,
+    "iron": [
+        "nine",
+        "popular",
+        "in",
+        "beautiful",
+        "everything",
+        "highway"
+    ],
+    "oxygen": 14.056527111644934,
+    "like": null,
+    "tower": "step slightly mountain",
+    "cross": null,
+    "met": 15,
+    "him": null,
+    "larger": [
+        4395,
+        1538,
+        2683
+    ],
+    "sound": false,
+    "sent": 75.86271985627096,
+    "blood": "sitting",
+    "won": true,
+    "loss": true,
+    "horse": [
+        "particularly",
+        "alive",
+        "hope",
+        "zipper",
+        "indicate"
+    ],
+    "naturally": {
+        "garden": 1181,
+        "every": 1587,
+        "stood": [
+            2460,
+            1034,
+            1390,
+            2587
+        ]
+    },
+    "thank": null,
+    "together": 233,
+    "claws": false,
+    "cup": [
+        "tent",
+        "seen",
+        "face",
+        "studied",
+        "whale"
+    ],
+    "jet": {
+        "ocean": "gift",
+        "directly": {
+            "vertical": [
+                4369,
+                674,
+                346,
+                2371
+            ]
+        },
+        "brief": [
+            "island",
+            "period",
+            "oldest",
+            "give",
+            "summer",
+            "setting"
+        ]
+    },
+    "fewer": 1164,
+    "needle": "species bowl",
+    "equally": false,
+    "became": null,
+    "pencil": 41.229172745552646,
+    "partly": "symbol soil",
+    "boat": 21.058755397980455,
+    "capital": true,
+    "wall": [
+        3575,
+        2898
+    ],
+    "diameter": [
+        "topic",
+        "situation"
+    ],
+    "swung": 1164,
+    "type": "week shall",
+    "decide": {
+        "crack": {}
+    },
+    "people": "function son rhythm",
+    "dream": "minute camp",
+    "donkey": [
+        3354,
+        257,
+        218
+    ],
+    "pattern": null,
+    "help": {
+        "nose": "length"
+    },
+    "develop": 450,
+    "nobody": 191,
+    "object": 7.423494979256451,
+    "arm": null,
+    "wife": [
+        4261,
+        2363,
+        699
+    ],
+    "sheet": 1618,
+    "cave": false,
+    "scared": 79.40581014225971,
+    "crack": {
+        "pain": {},
+        "eager": 91.20877688850891,
+        "climb": 1866
+    },
+    "wool": false,
+    "facing": 62.75822807506075,
+    "gather": true,
+    "fairly": "distant",
+    "bound": [
+        2696,
+        1684,
+        4967,
+        3899
+    ],
+    "bridge": null,
+    "shall": 1024,
+    "answer": {
+        "younger": {},
+        "vegetable": "gas driver process is",
+        "whispered": "closely basket"
+    },
+    "steep": false,
+    "attempt": [
+        "piano",
+        "ask",
+        "street",
+        "upper"
+    ],
+    "tide": true,
+    "lower": 1794,
+    "applied": 1452,
+    "apart": "dry",
+    "including": null,
+    "scale": 159,
+    "shadow": 28.901132149359164,
+    "here": true,
+    "cover": false,
+    "arrangement": true,
+    "course": true,
+    "picture": false,
+    "slip": {
+        "harbor": true,
+        "noon": [
+            2190,
+            751,
+            4192,
+            4065,
+            3492,
+            1261
+        ]
+    },
+    "share": 654,
+    "pull": [
+        3640,
+        4819,
+        4364,
+        4908
+    ],
+    "if": [
+        "clay",
+        "with"
+    ],
+    "rod": null,
+    "valley": null,
+    "basic": "seeing kitchen prevent jet",
+    "noun": false,
+    "butter": 26.10031366946184,
+    "unusual": 70,
+    "sun": false,
+    "motion": [
+        1485,
+        2103,
+        690
+    ],
+    "evening": {
+        "location": {
+            "down": {
+                "list": 17.512262000815948,
+                "which": {
+                    "beneath": "grow war stone apart"
+                }
+            },
+            "attention": null
+        },
+        "fine": 47.54797527711896
+    },
+    "peace": true,
+    "cotton": [
+        "surface",
+        "poem",
+        "frame",
+        "essential"
+    ],
+    "angle": 64.46131202875225,
+    "safe": 357,
+    "faster": null,
+    "unhappy": 1075,
+    "race": null,
+    "sink": {
+        "piano": [
+            3863,
+            1365,
+            967,
+            4760
+        ],
+        "hat": [
+            3273,
+            3723,
+            2979,
+            3868
+        ],
+        "watch": {}
+    },
+    "quietly": [
+        "cell",
+        "poem",
+        "although"
+    ],
+    "somebody": "discover",
+    "arrow": [
+        3352,
+        693,
+        4214,
+        2089,
+        3391
+    ],
+    "anyone": null,
+    "truck": "safety observe shelter are wooden",
+    "compass": 45.617320787542795,
+    "dust": "page continued melted",
+    "task": 588,
+    "thrown": "compare managed gradually try combination",
+    "settle": 60.54616570050122,
+    "contain": 44.94781737929414,
+    "describe": null,
+    "production": false,
+    "had": "difficult fly magnet",
+    "room": false,
+    "rabbit": null,
+    "exactly": true,
+    "before": "jet period large garage",
+    "dollar": true,
+    "because": {
+        "afraid": "group alive hardly",
+        "teeth": 43.53744810492633
+    },
+    "is": 1727,
+    "building": 36.49330295883946,
+    "least": {
+        "modern": [
+            73,
+            4136
+        ],
+        "poetry": null
+    },
+    "verb": "chief favorite",
+    "depend": 59.810594248200545,
+    "memory": [
+        458,
+        3958,
+        2646
+    ],
+    "position": null,
+    "excitement": 898,
+    "substance": {
+        "person": {},
+        "country": 1626
+    },
+    "talk": 1368,
+    "perfect": "pool cook",
+    "pot": "peace best cast my mighty",
+    "continued": false,
+    "note": "mix breakfast",
+    "locate": {
+        "inside": "longer distance sick rising fog",
+        "thirty": 67.87610223140996
+    },
+    "sail": false,
+    "parallel": [
+        4385,
+        2760,
+        4831
+    ],
+    "fly": 14.75232968831195,
+    "topic": {
+        "daughter": true,
+        "its": false,
+        "research": {
+            "sometime": "afternoon tool",
+            "anybody": 1952,
+            "paragraph": 1263
+        }
+    },
+    "getting": false,
+    "rhyme": false,
+    "report": "roar company suggest hide",
+    "monkey": 53.875081457386244,
+    "piece": null,
+    "fix": {
+        "because": [
+            2960,
+            1101,
+            4344,
+            3233,
+            2671
+        ]
+    },
+    "separate": [
+        "then",
+        "recent",
+        "fourth"
+    ],
+    "rocket": 67.12044820949427,
+    "actual": 1940,
+    "remain": true,
+    "her": false,
+    "aware": [
+        "company",
+        "magic"
+    ],
+    "eager": [
+        "what",
+        "pressure",
+        "hardly",
+        "concerned"
+    ],
+    "explanation": {},
+    "half": 1746,
+    "snow": 9.830207825418835,
+    "stopped": 1943,
+    "section": "elephant",
+    "master": 1181,
+    "beat": null,
+    "completely": [
+        1473,
+        895
+    ],
+    "bus": 989,
+    "trouble": "feature",
+    "lead": 22.893144081959083,
+    "everybody": [
+        "sick",
+        "locate",
+        "character",
+        "seldom",
+        "rear",
+        "sing"
+    ],
+    "breathing": false,
+    "hand": "compare recall automobile discuss soon",
+    "adventure": [
+        1712,
+        4622,
+        3087,
+        2503
+    ],
+    "found": [
+        "explore",
+        "fierce",
+        "chosen",
+        "steam"
+    ],
+    "understanding": 1348,
+    "flat": "telephone grass feathers hour",
+    "location": 39.07672491599652,
+    "exist": [
+        1543,
+        1440,
+        4301,
+        4915
+    ],
+    "atmosphere": "hit post fought",
+    "neighborhood": 992,
+    "seldom": [
+        "hung",
+        "depth",
+        "contrast",
+        "ability"
+    ],
+    "heard": 882,
+    "among": "seeing understanding poor train",
+    "western": {
+        "grass": "statement shallow",
+        "hot": 29.373901791611367,
+        "accept": {
+            "still": 362,
+            "joined": "sometime dot"
+        }
+    },
+    "occasionally": 859,
+    "sweet": "border regular five receive",
+    "tales": "flame shown stems signal tea",
+    "total": 15.444441657909946,
+    "whale": [
+        374,
+        3177,
+        1657,
+        3069,
+        2258
+    ],
+    "part": 1903,
+    "know": "simplest strength clothing count",
+    "past": 47.688861884390185,
+    "moment": "still",
+    "either": 27.286282564732733,
+    "paper": 61.71232941953026,
+    "signal": "single level fill stomach baseball",
+    "hold": true,
+    "put": "doctor shape next fireplace our",
+    "next": null,
+    "lift": false,
+    "ahead": {
+        "primitive": "automobile throw stove"
+    },
+    "tip": false,
+    "universe": "once hall now perfectly",
+    "dry": null,
+    "plus": {
+        "piece": null,
+        "zulu": 70.62388813276164,
+        "led": {}
+    },
+    "moon": 93.27475098643635,
+    "industrial": null,
+    "doll": {},
+    "practice": 1874,
+    "flew": "doubt",
+    "play": true,
+    "period": false,
+    "allow": 32.83838264799983,
+    "wonderful": true,
+    "army": "everyone sign",
+    "money": "torn against almost bent",
+    "could": [
+        "pony",
+        "report",
+        "law",
+        "wet",
+        "aboard"
+    ],
+    "run": 42.22986362208514,
+    "radio": 386,
+    "knew": {
+        "stems": [
+            "soft",
+            "try",
+            "tip",
+            "health",
+            "how",
+            "onto"
+        ]
+    },
+    "cry": {
+        "swam": null,
+        "zulu": null,
+        "slave": [
+            149,
+            3515,
+            4399,
+            3971
+        ]
+    },
+    "brush": 41.26720646553124,
+    "stronger": false,
+    "skin": "arrow moving wheel",
+    "success": "shut know it suddenly pen",
+    "climb": 1996,
+    "season": 1125,
+    "garage": [
+        565,
+        1400,
+        327
+    ],
+    "language": true,
+    "program": [
+        "card",
+        "gasoline",
+        "hundred",
+        "him"
+    ],
+    "create": null,
+    "island": true,
+    "someone": {
+        "industrial": true,
+        "shake": true,
+        "blind": 552
+    },
+    "range": 1524,
+    "white": [
+        1331,
+        952,
+        1211,
+        1665
+    ],
+    "river": [
+        "adjective",
+        "stream",
+        "he",
+        "signal",
+        "such"
+    ],
+    "worth": null,
+    "stairs": null,
+    "earlier": null,
+    "lost": "letter cream short electric",
+    "got": [
+        357,
+        2302,
+        1407,
+        2415
+    ],
+    "chief": {
+        "closer": null,
+        "stuck": 106,
+        "free": true
+    },
+    "meal": {},
+    "concerned": false,
+    "furniture": true,
+    "men": 1452,
+    "out": [
+        "dawn",
+        "separate",
+        "corner"
+    ],
+    "observe": "surprise pink",
+    "bigger": [
+        131,
+        3090,
+        3459
+    ],
+    "character": null,
+    "said": [
+        "central",
+        "rock",
+        "yes"
+    ],
+    "thing": null,
+    "several": "interest chamber",
+    "were": "energy fire dust having putting",
+    "research": "life upon top",
+    "roof": [
+        "blow",
+        "symbol",
+        "balance"
+    ],
+    "nose": 97.07424698395259,
+    "book": 1594,
+    "finger": {
+        "growth": "swept decide leaf fewer interest",
+        "gray": "quiet crack",
+        "exercise": {}
+    },
+    "cannot": 695,
+    "melted": [
+        "cast",
+        "green",
+        "certain"
+    ],
+    "angry": [
+        "melted",
+        "including",
+        "done",
+        "fact"
+    ],
+    "porch": {},
+    "hole": 723,
+    "bit": "one track return bean cookies",
+    "dinner": null,
+    "mixture": false,
+    "rate": {
+        "space": null
+    },
+    "meet": 1002,
+    "handsome": "seeing except",
+    "social": true,
+    "calm": {},
+    "health": 24.2661643213979,
+    "given": 57.43962065929895,
+    "stretch": {
+        "pride": 1940,
+        "idea": false
+    },
+    "eventually": 68,
+    "public": 719,
+    "pale": {},
+    "ordinary": 1319,
+    "wind": false,
+    "audience": {
+        "wool": 51.91739895760852
+    },
+    "engine": {
+        "toward": [
+            "experiment",
+            "blank",
+            "compare",
+            "driving"
+        ],
+        "same": 72.38048749596706,
+        "early": {
+            "foot": "sad capital speech",
+            "coat": 1772,
+            "present": {
+                "younger": 20.47099585304213
+            }
+        }
+    },
+    "rose": [
+        1978,
+        108,
+        3773
+    ],
+    "shallow": {},
+    "mice": [
+        "whose",
+        "every"
+    ],
+    "motor": 1498,
+    "suggest": 1050,
+    "straight": null,
+    "rays": 326,
+    "date": 68.93086295484576,
+    "grown": null,
+    "adult": false,
+    "education": [
+        "bark",
+        "subject",
+        "wonderful"
+    ],
+    "roll": [
+        "dried",
+        "these",
+        "mail"
+    ],
+    "depth": "surrounded",
+    "national": "jet pass husband freedom turn",
+    "drink": 1588,
+    "nice": true,
+    "should": null,
+    "become": "rays fence hungry seems they",
+    "solid": [
+        4921,
+        4282,
+        534,
+        2162
+    ],
+    "chair": {},
+    "herd": 156,
+    "lady": {
+        "doubt": 1439
+    },
+    "likely": 22.180237177396613,
+    "business": {
+        "body": "warm hang",
+        "strength": 84.48632236942974
+    },
+    "rubber": 984,
+    "newspaper": {
+        "price": {}
+    },
+    "tightly": [
+        2518,
+        2188
+    ],
+    "troops": {
+        "may": "tea steep"
+    },
+    "heavy": "pour dangerous mysterious kids",
+    "into": [
+        342,
+        200,
+        656
+    ],
+    "cook": 454,
+    "solution": [
+        285,
+        4763,
+        4967,
+        4836
+    ],
+    "value": [
+        2130,
+        2092
+    ],
+    "felt": 691,
+    "kitchen": true,
+    "cheese": 102,
+    "alive": null,
+    "remember": "yes gray jack",
+    "fellow": null,
+    "supper": null,
+    "boy": null,
+    "air": [
+        3170,
+        1465,
+        3921
+    ],
+    "silver": 9.418458348928006,
+    "funny": false,
+    "trunk": 1045,
+    "tobacco": 9.057242849312486,
+    "team": 32.72911108091081,
+    "ran": [
+        3276,
+        962,
+        1256
+    ],
+    "engineer": false,
+    "personal": "push involved",
+    "teacher": {
+        "engineer": 55.94328197066651
+    },
+    "ancient": [
+        "join",
+        "national",
+        "shoulder"
+    ],
+    "rising": true,
+    "swept": 8.165235531485294,
+    "gulf": 1509,
+    "silence": true,
+    "hundred": "examine",
+    "drew": 1949,
+    "ought": {},
+    "school": false,
+    "poet": {
+        "government": true,
+        "frequently": [
+            4187,
+            2371
+        ]
+    },
+    "dress": {
+        "making": [
+            "cat",
+            "keep"
+        ],
+        "won": {
+            "thy": "band hurry city adult young",
+            "send": [
+                "reach",
+                "cost",
+                "tape"
+            ],
+            "flew": [
+                "language",
+                "slightly",
+                "better",
+                "question",
+                "case",
+                "ought"
+            ]
+        },
+        "replied": 262
+    },
+    "sense": 1893,
+    "merely": "science slipped",
+    "eye": [
+        "place",
+        "zero",
+        "young",
+        "mood",
+        "baseball"
+    ],
+    "graph": [
+        "captain",
+        "count",
+        "position"
+    ],
+    "needed": 48.72110576369646,
+    "push": 74.37534697314359,
+    "factor": null,
+    "person": [
+        "shoe",
+        "test",
+        "build",
+        "friendly",
+        "stairs"
+    ],
+    "fell": true,
+    "tears": "bad bad cat rhyme below",
+    "along": 0.019710059127753254,
+    "twelve": "rock have pour explain",
+    "make": false,
+    "will": {
+        "horse": true,
+        "mysterious": true
+    },
+    "weather": "struggle gray",
+    "laid": "got perhaps",
+    "serious": 65.70255111778056,
+    "cast": true,
+    "why": 26.572763207968066,
+    "face": null,
+    "daughter": {
+        "pictured": "should opinion nuts"
+    },
+    "bone": 462,
+    "probably": null,
+    "food": 97,
+    "edge": 95.06929965960222,
+    "one": false,
+    "thread": "said",
+    "powder": 1233,
+    "recently": 51.420572712685875,
+    "happen": false,
+    "now": false,
+    "hidden": true,
+    "accept": [
+        "speak",
+        "sink",
+        "square"
+    ],
+    "present": {},
+    "victory": "allow give was support",
+    "southern": 97.77634661849702,
+    "teach": [
+        3587,
+        371,
+        3712,
+        2704,
+        4510
+    ],
+    "age": null,
+    "standard": 1148,
+    "breathe": true,
+    "long": "massage would continued explain exclaimed",
+    "shown": [
+        97,
+        2461,
+        3462
+    ],
+    "question": 644,
+    "tried": 1.7386763430527807,
+    "labor": true,
+    "electric": null,
+    "yard": [
+        "porch",
+        "elephant",
+        "coal",
+        "parent",
+        "lying",
+        "floating"
+    ],
+    "fact": {},
+    "day": [
+        598,
+        2791,
+        2006
+    ],
+    "trap": [
+        "feel",
+        "stomach",
+        "judge",
+        "secret"
+    ],
+    "pile": [
+        "look",
+        "cell",
+        "nation",
+        "ahead",
+        "properly",
+        "glad"
+    ],
+    "card": "job",
+    "my": "shelf explore major chief there",
+    "blow": {
+        "practical": false
+    },
+    "action": 26.1391774833565,
+    "lack": {
+        "last": true,
+        "enter": "join busy nation",
+        "find": null
+    },
+    "whom": null,
+    "writer": {},
+    "according": 1759,
+    "accurate": "birds gently closely",
+    "short": null,
+    "leather": null,
+    "good": null,
+    "leader": {
+        "brother": null,
+        "bag": [
+            4836,
+            1755,
+            4892
+        ]
+    },
+    "courage": [
+        "flame",
+        "valuable",
+        "onto",
+        "level",
+        "mighty",
+        "with"
+    ],
+    "child": "anyway some zebra easier",
+    "front": 97.42250359563249,
+    "stepped": [
+        "saved",
+        "rough",
+        "running",
+        "find",
+        "pure",
+        "instant"
+    ],
+    "rice": "danger positive opinion fresh alone",
+    "pound": 1427,
+    "live": null,
+    "work": {
+        "diameter": null,
+        "battle": "twelve became television hide pocket",
+        "dead": [
+            "consonant",
+            "outside",
+            "adventure",
+            "ask"
+        ]
+    },
+    "stems": 5.81436845541714,
+    "steam": "car problem",
+    "go": 1611,
+    "warn": {
+        "guess": null,
+        "met": 207
+    },
+    "member": 547,
+    "hour": null,
+    "grandfather": 88.05816002641045,
+    "theory": false,
+    "condition": 222,
+    "kind": 1056,
+    "full": [
+        130,
+        1679,
+        431,
+        3741
+    ],
+    "on": 82.57793238078857,
+    "automobile": null,
+    "belt": {},
+    "dance": [
+        "author",
+        "weak",
+        "bell",
+        "stranger"
+    ],
+    "turn": true,
+    "impossible": null,
+    "rapidly": null,
+    "camp": null,
+    "rather": "fireplace",
+    "immediately": false,
+    "low": null,
+    "harbor": null,
+    "wagon": null,
+    "enough": 49.57981514600185,
+    "appearance": "refer orbit",
+    "lovely": {},
+    "lungs": false,
+    "thou": 1641,
+    "explore": [
+        "judge",
+        "snake",
+        "tired",
+        "environment",
+        "from"
+    ],
+    "space": true,
+    "swimming": null,
+    "highest": "rod tightly southern",
+    "show": null,
+    "string": [
+        4035,
+        454,
+        3524
+    ],
+    "began": null,
+    "natural": [
+        750,
+        1299,
+        4218
+    ],
+    "throughout": {
+        "whale": null,
+        "known": {
+            "determine": false
+        },
+        "nose": 42.87040909944591
+    },
+    "shut": true,
+    "might": [
+        3458,
+        2245,
+        570
+    ],
+    "never": 1621,
+    "finally": [
+        "cook",
+        "horse",
+        "pot",
+        "eager",
+        "directly"
+    ],
+    "therefore": true,
+    "state": [
+        "kind",
+        "nest",
+        "alive"
+    ],
+    "street": false,
+    "tight": 1183,
+    "aloud": {
+        "bottom": [
+            "stop",
+            "there",
+            "matter",
+            "railroad",
+            "early",
+            "saw"
+        ]
+    },
+    "pick": true,
+    "lips": "suggest pale ordinary appearance",
+    "each": "throughout no",
+    "experiment": "swept smooth hollow",
+    "golden": {
+        "scientist": [
+            "seems",
+            "window"
+        ]
+    },
+    "noise": 19.219681906354168,
+    "has": false,
+    "muscle": false,
+    "ill": null,
+    "plane": [
+        3340,
+        3836
+    ],
+    "done": 11.62537907185821,
+    "anyway": 6,
+    "another": 1799,
+    "effort": null,
+    "anybody": {
+        "fallen": false,
+        "dirty": 3.1778978508975264
+    },
+    "orange": null,
+    "feet": "certain page",
+    "activity": 714,
+    "give": 1995,
+    "stop": "shoulder rhythm vowel fierce grandmother",
+    "knowledge": null,
+    "other": false,
+    "life": 91.79495521355163,
+    "double": 42.66614981184935,
+    "deal": 86.55455984583998,
+    "bear": {
+        "describe": {
+            "men": [
+                "particularly",
+                "within",
+                "weigh",
+                "stream"
+            ],
+            "sing": 248,
+            "been": [
+                "truth",
+                "flower",
+                "mathematics",
+                "applied",
+                "lay"
+            ]
+        }
+    },
+    "correctly": [
+        "summer",
+        "personal",
+        "service",
+        "factor",
+        "operation",
+        "gasoline"
+    ],
+    "game": {
+        "score": [
+            2548,
+            2310,
+            4115
+        ],
+        "four": "minute"
+    },
+    "kill": 1321,
+    "traffic": {
+        "completely": "port show frame"
+    },
+    "managed": [
+        "rate",
+        "behavior",
+        "possibly",
+        "master",
+        "like",
+        "let"
+    ],
+    "threw": {},
+    "higher": "zebra",
+    "whose": "discover noise wave exact disease",
+    "famous": [
+        "change",
+        "rope",
+        "wash",
+        "rocky"
+    ],
+    "where": 60.485089426109354,
+    "lion": null,
+    "chose": null,
+    "plate": null,
+    "extra": {
+        "snake": {},
+        "building": 18.15715341500388,
+        "successful": false
+    },
+    "few": 1209,
+    "jar": null,
+    "forth": 834,
+    "log": "limited type hardly choose arrange",
+    "page": 538,
+    "necessary": null,
+    "wing": "somebody stay anybody face fence",
+    "brave": [
+        3080,
+        4966,
+        4291,
+        4615
+    ],
+    "read": "enter syllable police model importance",
+    "fog": 62.20812329234724,
+    "important": true,
+    "later": [
+        178,
+        2488,
+        440,
+        705
+    ],
+    "cent": 1595,
+    "brief": 19.591682693101077,
+    "away": {
+        "book": {
+            "disease": {
+                "direct": "bat consist easier arm"
+            },
+            "hunt": {
+                "classroom": {
+                    "political": {
+                        "plates": null,
+                        "period": 410
+                    },
+                    "slipped": {
+                        "manufacturing": {},
+                        "period": "experiment catch person attempt",
+                        "too": {
+                            "electric": "public fell"
+                        }
+                    },
+                    "get": "center"
+                }
+            },
+            "wood": 673
+        },
+        "could": {
+            "needle": {
+                "essential": false,
+                "wait": [
+                    3363,
+                    2946,
+                    1561
+                ]
+            }
+        },
+        "satellites": 1744
+    },
+    "area": {},
+    "plant": "folks chance special ourselves ought",
+    "torn": null,
+    "smile": 72.03964218453171,
+    "darkness": "catch fort start",
+    "mix": null,
+    "consonant": true,
+    "perfectly": true,
+    "valuable": 38.539432362636084,
+    "shaking": "half say ruler south shorter",
+    "middle": "yourself property explanation hidden",
+    "giant": "wooden instant driver bean size",
+    "medicine": "visitor help west numeral signal",
+    "mass": 502,
+    "grabbed": true,
+    "saved": 1731,
+    "dull": 9.578588652460795,
+    "swam": {
+        "chance": null
+    },
+    "corner": 1282,
+    "split": 21.373350599462103,
+    "rock": "notice",
+    "sugar": [
+        "welcome",
+        "affect",
+        "sunlight",
+        "did"
+    ],
+    "see": 59.01493312842436,
+    "bank": null,
+    "paid": false,
+    "major": [
+        2646,
+        2881
+    ],
+    "step": 1652,
+    "college": null,
+    "taught": 33.331607088500135,
+    "electricity": "pink hit light",
+    "grain": {},
+    "agree": {
+        "bow": 69.82201275767783,
+        "lower": 28.02564298339203
+    },
+    "behind": "planned basic",
+    "problem": [
+        "something",
+        "rhythm",
+        "sweet",
+        "trail",
+        "wish",
+        "single"
+    ],
+    "symbol": [
+        1405,
+        703,
+        1425
+    ],
+    "say": 4.064653949587815,
+    "year": {},
+    "equal": [
+        "color",
+        "rich",
+        "final",
+        "suppose",
+        "sense",
+        "had"
+    ],
+    "planning": 953,
+    "sat": 95.03816372667897,
+    "biggest": 61.32707518095029,
+    "quickly": [
+        3169,
+        2125,
+        1662,
+        1478,
+        2850
+    ],
+    "whether": 1904,
+    "dear": [
+        "string",
+        "rocky",
+        "drove",
+        "wood",
+        "occur"
+    ],
+    "earn": null,
+    "goes": {},
+    "prize": "promised movie east plan",
+    "can": null,
+    "easier": {
+        "modern": 1851,
+        "shaking": 17.7251402184174,
+        "station": 10.120935758420725
+    },
+    "how": null,
+    "corn": {},
+    "pay": 5.125902309602615,
+    "affect": null,
+    "across": 92.12331453224473,
+    "clock": [
+        3935,
+        1263,
+        2314,
+        2639
+    ],
+    "great": false,
+    "driving": true,
+    "union": [
+        789,
+        1642
+    ],
+    "tonight": true,
+    "slow": true,
+    "flame": {
+        "printed": null,
+        "west": true
+    },
+    "tired": "perhaps feature",
+    "height": [
+        "skin",
+        "skill",
+        "has",
+        "opportunity"
+    ],
+    "farm": "control cream refer everyone",
+    "studying": {},
+    "pilot": 310,
+    "post": false,
+    "station": 469,
+    "new": {
+        "hat": {
+            "certainly": 1980,
+            "hurt": 63.030583947190436,
+            "station": 1085
+        },
+        "symbol": "triangle visitor box atom plant",
+        "pole": 741
+    },
+    "tube": {},
+    "leave": null,
+    "author": null,
+    "cap": null,
+    "song": true,
+    "beauty": 39.185716501562,
+    "discussion": 73.80616442270681,
+    "studied": [
+        "giving",
+        "town",
+        "mixture",
+        "mix"
+    ],
+    "apple": [
+        187,
+        4699
+    ],
+    "diagram": 1596,
+    "addition": false,
+    "bow": 728,
+    "recall": 2.8160549176871053,
+    "individual": {
+        "familiar": {
+            "rapidly": {
+                "cat": "lesson whatever castle medicine",
+                "above": true,
+                "science": {
+                    "quietly": 1169
+                }
+            },
+            "care": {
+                "pie": 13.830470635409299,
+                "five": 53.096300487834135,
+                "wonder": 318
+            },
+            "rise": false
+        }
+    },
+    "living": 30.321353443766206,
+    "characteristic": null,
+    "goose": "paint foreign",
+    "rest": false,
+    "all": "barn expression impossible swam",
+    "sunlight": 86.02691175573678,
+    "safety": true,
+    "include": "officer",
+    "regular": {
+        "pet": 1128,
+        "definition": {}
+    },
+    "average": {
+        "differ": 1837,
+        "means": null
+    },
+    "manner": {
+        "early": true,
+        "carry": {
+            "percent": "difficult poem glass government",
+            "crowd": 1440
+        },
+        "force": true
+    },
+    "coffee": true,
+    "select": "shot food does fed breathe",
+    "variety": true,
+    "seeing": [
+        4911,
+        3126,
+        4147
+    ],
+    "breath": [
+        "brave",
+        "pine",
+        "bring"
+    ],
+    "five": "compare declared underline struck",
+    "ever": {
+        "sort": false,
+        "bark": [
+            "generally",
+            "becoming",
+            "equally",
+            "clean"
+        ],
+        "search": "number animal plane sure"
+    },
+    "water": 1133,
+    "strip": "mistake ordinary space thought pocket",
+    "buffalo": null,
+    "fox": 1013,
+    "somewhere": "down",
+    "history": 52.50775242409163,
+    "sky": null,
+    "dried": 683,
+    "metal": [
+        "saw",
+        "freedom"
+    ],
+    "please": null,
+    "broken": {
+        "her": 816
+    },
+    "between": true,
+    "passage": [
+        "human",
+        "hungry",
+        "they"
+    ],
+    "prevent": true,
+    "exercise": 92,
+    "spent": null,
+    "act": "fall sat correctly",
+    "listen": {},
+    "opportunity": 15.455256631335335,
+    "fur": {},
+    "movement": null,
+    "classroom": 503,
+    "spirit": null,
+    "women": {
+        "respect": 1697,
+        "forgotten": {},
+        "chain": null
+    },
+    "volume": [
+        "dangerous",
+        "country",
+        "chief",
+        "unhappy"
+    ],
+    "mistake": true,
+    "actually": "into help",
+    "party": false,
+    "folks": [
+        3801,
+        1165,
+        4830,
+        3391
+    ],
+    "orbit": 1235,
+    "reader": {
+        "affect": {
+            "needs": 784,
+            "rather": 79,
+            "general": 1239
+        },
+        "get": "hot buffalo",
+        "them": [
+            4181,
+            2755,
+            3346
+        ]
+    },
+    "terrible": [
+        "lion",
+        "metal",
+        "parts",
+        "might",
+        "might",
+        "nobody"
+    ]
+}


### PR DESCRIPTION
Context: https://github.com/wundergraph/astjson/pull/5

I retested it. The improvements are still significant and valid.

<img width="4016" height="2226" alt="CleanShot 2025-09-06 at 23 13 11@2x" src="https://github.com/user-attachments/assets/708e179b-9fb5-4215-b86b-3eab1b831ff0" />
