### PR TITLE
fix: ensure GC safety for arena-allocated values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.5.0
+          version: v2.10.1
   ci:
     name: CI Success
     if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: ^1.25
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.26' ]
+        go: [ '1.25' ]
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Set git to use LF
@@ -42,11 +42,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: ^1.26
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.10.1
+          version: v2.5.0
   ci:
     name: CI Success
     if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.25' ]
+        go: [ '1.26' ]
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Set git to use LF
@@ -42,11 +42,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: ^1.25
+          go-version: ^1.26
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.5.0
+          version: v2.10.1
   ci:
     name: CI Success
     if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -1,103 +1,380 @@
 [![Build Status](https://github.com/wundergraph/astjson/actions/workflows/ci.yml/badge.svg)](https://github.com/wundergraph/astjson/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/wundergraph/astjson.svg)](https://pkg.go.dev/github.com/wundergraph/astjson)
 
-# fastjson - fast JSON parser and validator for Go
+# astjson - fast JSON parser and validator for Go
 
 
 ## Features
 
-  * Fast. As usual, up to 15x faster than the standard [encoding/json](https://golang.org/pkg/encoding/json/).
+  * Fast. Up to 15x faster than the standard [encoding/json](https://golang.org/pkg/encoding/json/).
     See [benchmarks](#benchmarks).
-  * Parses arbitrary JSON without schema, reflection, struct magic and code generation
-    contrary to [easyjson](https://github.com/mailru/easyjson).
-  * Provides simple [API](http://godoc.org/github.com/wundergraph/astjson).
+  * Parses arbitrary JSON without schema, reflection, struct magic and code generation.
+  * Optional arena allocation for zero-GC-overhead parsing in high-throughput paths.
   * Outperforms [jsonparser](https://github.com/buger/jsonparser) and [gjson](https://github.com/tidwall/gjson)
-    when accessing multiple unrelated fields, since `fastjson` parses the input JSON only once.
+    when accessing multiple unrelated fields, since `astjson` parses the input JSON only once.
   * Validates the parsed JSON unlike [jsonparser](https://github.com/buger/jsonparser)
     and [gjson](https://github.com/tidwall/gjson).
-  * May quickly extract a part of the original JSON with `Value.Get(...).MarshalTo` and modify it
-    with [Del](https://godoc.org/github.com/wundergraph/astjson#Value.Del)
-    and [Set](https://godoc.org/github.com/wundergraph/astjson#Value.Set) functions.
-  * May parse array containing values with distinct types (aka non-homogenous types).
-    For instance, `fastjson` easily parses the following JSON array `[123, "foo", [456], {"k": "v"}, null]`.
-  * `fastjson` preserves the original order of object items when calling
+  * Extract, modify, and re-serialize parts of JSON with `Value.Get(...).MarshalTo`,
+    [Del](https://godoc.org/github.com/wundergraph/astjson#Value.Del),
+    and [Set](https://godoc.org/github.com/wundergraph/astjson#Value.Set).
+  * Parses arrays containing values with distinct types (non-homogenous).
+  * Preserves the original order of object keys when calling
     [Object.Visit](https://godoc.org/github.com/wundergraph/astjson#Object.Visit).
 
 
 ## Known limitations
 
-  * Requies extra care to work with - references to certain objects recursively
-    returned by [Parser](https://godoc.org/github.com/wundergraph/astjson#Parser)
-    must be released before the next call to [Parse](https://godoc.org/github.com/wundergraph/astjson#Parser.Parse).
-    Otherwise the program may work improperly. The same applies to objects returned by [Arena](https://godoc.org/github.com/wundergraph/astjson#Arena).
-    Adhere recommendations from [docs](https://godoc.org/github.com/wundergraph/astjson).
-  * Cannot parse JSON from `io.Reader`. There is [Scanner](https://godoc.org/github.com/wundergraph/astjson#Scanner)
-    for parsing stream of JSON values from a string.
+  * Not safe for concurrent use. Use per-goroutine `Parser`, `Value`, and `Scanner` instances.
+  * Cannot parse JSON from `io.Reader`. Use [Scanner](https://godoc.org/github.com/wundergraph/astjson#Scanner)
+    for parsing a stream of JSON values from a string.
 
 
 ## Usage
 
-One-liner accessing a single field:
-```go
-	s := []byte(`{"foo": [123, "bar"]}`)
-	fmt.Printf("foo.0=%d\n", fastjson.GetInt(s, "foo", "0"))
+### One-liner field access
 
-	// Output:
-	// foo.0=123
+For quick, single-field extraction from `[]byte` input:
+
+```go
+s := []byte(`{"foo": [123, "bar"]}`)
+fmt.Printf("foo.0=%d\n", astjson.GetInt(s, "foo", "0"))
+// Output: foo.0=123
 ```
 
-Accessing multiple fields with error handling:
-```go
-        var p fastjson.Parser
-        v, err := p.Parse(`{
-                "str": "bar",
-                "int": 123,
-                "float": 1.23,
-                "bool": true,
-                "arr": [1, "foo", {}]
-        }`)
-        if err != nil {
-                log.Fatal(err)
-        }
-        fmt.Printf("foo=%s\n", v.GetStringBytes("str"))
-        fmt.Printf("int=%d\n", v.GetInt("int"))
-        fmt.Printf("float=%f\n", v.GetFloat64("float"))
-        fmt.Printf("bool=%v\n", v.GetBool("bool"))
-        fmt.Printf("arr.1=%s\n", v.GetStringBytes("arr", "1"))
+Other one-liners: `GetString`, `GetBytes`, `GetFloat64`, `GetBool`, `Exists`.
 
-        // Output:
-        // foo=bar
-        // int=123
-        // float=1.230000
-        // bool=true
-        // arr.1=foo
+### Parsing with a Parser
+
+When you need multiple fields from the same JSON, parse once and query:
+
+```go
+var p astjson.Parser
+v, err := p.Parse(`{
+    "str": "bar",
+    "int": 123,
+    "float": 1.23,
+    "bool": true,
+    "arr": [1, "foo", {}]
+}`)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("str=%s\n", v.GetStringBytes("str"))
+fmt.Printf("int=%d\n", v.GetInt("int"))
+fmt.Printf("float=%f\n", v.GetFloat64("float"))
+fmt.Printf("bool=%v\n", v.GetBool("bool"))
+fmt.Printf("arr.1=%s\n", v.GetStringBytes("arr", "1"))
 ```
 
-See also [examples](https://godoc.org/github.com/wundergraph/astjson#pkg-examples).
+Use `Get` for deep path access. Array elements are accessed by index as a string key:
+
+```go
+v.Get("users", "0", "name")          // first user's name
+v.GetInt("matrix", "1", "2")         // matrix[1][2] as int
+```
+
+### Arena-mode parsing
+
+Arena mode allocates all parsed values on a monotonic arena instead of the heap,
+eliminating GC pressure. See [GC & Arena Safety](#gc--arena-safety) for the rules.
+
+```go
+a := arena.NewMonotonicArena()
+var p astjson.Parser
+v, err := p.ParseWithArena(a, `{"name": "alice", "age": 30}`)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("name=%s\n", v.GetStringBytes("name"))
+// v is valid for the lifetime of a
+```
+
+The input string is copied onto the arena automatically — the caller can drop
+the reference to it immediately after parsing.
+
+### Creating values
+
+Value constructors accept an `arena.Arena` — pass `nil` for heap allocation:
+
+```go
+a := arena.NewMonotonicArena()
+
+s := astjson.StringValue(a, "hello")      // arena-allocated string
+n := astjson.IntValue(a, 42)              // arena-allocated number
+f := astjson.FloatValue(a, 3.14)          // arena-allocated float
+b := astjson.TrueValue(a)                 // arena-allocated true
+obj := astjson.ObjectValue(a)             // empty object
+arr := astjson.ArrayValue(a)              // empty array
+
+// Heap-allocated (pass nil):
+heapStr := astjson.StringValue(nil, "heap")
+```
+
+Also available: `FalseValue`, `NumberValue` (raw numeric string), `StringValueBytes`.
+
+### Modifying JSON
+
+**Set object fields:**
+
+```go
+a := arena.NewMonotonicArena()
+v, _ := p.ParseWithArena(a, `{"foo": 1}`)
+v.Set(a, "foo", astjson.StringValue(a, "updated"))
+v.Set(a, "bar", astjson.IntValue(a, 2))
+fmt.Println(v) // {"foo":"updated","bar":2}
+```
+
+**Delete fields:**
+
+```go
+v.Del("foo")        // delete from object
+v.Del("0")          // delete index 0 from array
+```
+
+**Set array items:**
+
+```go
+arr, _ := p.ParseWithArena(a, `[1, 2, 3]`)
+arr.SetArrayItem(a, 1, astjson.StringValue(a, "two"))
+fmt.Println(arr) // [1,"two",3]
+```
+
+**Append to array:**
+
+```go
+arr := astjson.ArrayValue(a)
+astjson.AppendToArray(a, arr, astjson.IntValue(a, 1))
+astjson.AppendToArray(a, arr, astjson.IntValue(a, 2))
+fmt.Println(arr) // [1,2]
+```
+
+**Set deeply nested paths (creates intermediate objects):**
+
+```go
+v := astjson.MustParse(`{}`)
+astjson.SetValue(nil, v, astjson.IntValue(nil, 42), "a", "b", "c")
+fmt.Println(v) // {"a":{"b":{"c":42}}}
+```
+
+### Merging values
+
+`MergeValues` recursively merges two values. For objects, keys from `b` are
+added to or replace keys in `a`. For arrays, elements are merged pairwise
+(arrays must have equal length). For scalars, `b` replaces `a` when they differ.
+
+```go
+a := arena.NewMonotonicArena()
+var p astjson.Parser
+base, _ := p.ParseWithArena(a, `{"name": "alice", "age": 30}`)
+overlay, _ := p.ParseWithArena(a, `{"age": 31, "email": "alice@example.com"}`)
+
+merged, changed, err := astjson.MergeValues(a, base, overlay)
+fmt.Println(merged) // {"name":"alice","age":31,"email":"alice@example.com"}
+```
+
+`MergeValuesWithPath` wraps `b` in a nested object at the given path before merging:
+
+```go
+extra, _ := p.ParseWithArena(a, `"1.0"`)
+merged, _, _ = astjson.MergeValuesWithPath(a, base, extra, "metadata", "version")
+// equivalent to merging {"metadata":{"version":"1.0"}} into base
+```
+
+### Iterating objects
+
+```go
+v, _ := p.Parse(`{"a": 1, "b": "two", "c": [3]}`)
+o, _ := v.Object()
+o.Visit(func(key []byte, val *astjson.Value) {
+    fmt.Printf("%s: %s\n", key, val)
+})
+// a: 1
+// b: "two"
+// c: [3]
+```
+
+Object keys are visited in their original order. The `key` slice and `val`
+pointer must not be retained after the callback returns.
+
+### Scanning a stream of JSON values
+
+```go
+var sc astjson.Scanner
+sc.Init(`{"foo":"bar"} [1,2] "hello" true 42`)
+for sc.Next() {
+    fmt.Printf("%s\n", sc.Value())
+}
+if err := sc.Error(); err != nil {
+    log.Fatal(err)
+}
+```
+
+### Serialization
+
+```go
+// Serialize to a new byte slice:
+data := v.MarshalTo(nil)
+
+// Append to an existing buffer:
+buf = v.MarshalTo(buf)
+
+// Get a string representation:
+s := v.String()
+```
+
+### DeepCopy
+
+`DeepCopy` creates a complete copy of a value tree on the given arena. This is
+the safe way to insert heap-allocated values into arena-allocated containers:
+
+```go
+a := arena.NewMonotonicArena()
+obj := astjson.ObjectValue(a)
+
+heapVal, _ := astjson.Parse(`{"nested": "data"}`)
+obj.Set(a, "key", astjson.DeepCopy(a, heapVal))  // safe: copy lives in arena
+```
+
+When `a` is nil, `DeepCopy` returns the value unchanged (no-op in heap mode).
+
+
+## GC & Arena Safety
+
+This section is critical reading if you use arena mode. Misuse leads to
+**silent use-after-free** bugs that are difficult to diagnose.
+
+### Heap mode vs arena mode
+
+| | Heap mode (`nil` arena) | Arena mode (non-nil arena) |
+|---|---|---|
+| **Allocation** | Standard Go heap | Monotonic arena bump allocator |
+| **GC tracking** | All pointers traced normally | Arena memory is **invisible** to GC |
+| **Lifetime** | Until GC collects (no live refs) | Until the arena is dropped/reset |
+| **When to use** | Simple cases, low throughput | High throughput, request-scoped work |
+
+### The noscan invariant
+
+Arena buffers are allocated as `[]byte` slabs. Go's GC treats `[]byte` as
+containing no pointers — it never scans inside them. This means **any pointer
+stored in arena memory is invisible to the GC**. This includes:
+
+  * `Value.a` (`[]*Value`) — array element pointers
+  * `Object.kvs` (`[]*kv`) — key-value entry pointers
+  * `kv.v` (`*Value`) — value pointers inside object entries
+  * `Value.s` / `kv.k` (`string`) — string data pointers
+
+The library maintains safety by copying all string data onto the arena when
+a non-nil arena is provided. But **pointer fields to Value structs** are the
+caller's responsibility when inserting values across allocation boundaries.
+
+### The golden rule
+
+> **Never store a heap-allocated `*Value` into an arena-allocated container
+> unless another GC-visible reference keeps it alive.**
+
+If the only reference to a heap Value lives in arena memory, the GC cannot see
+it and may collect it, causing a use-after-free. Use `DeepCopy` to copy the
+value onto the arena first.
+
+**Unsafe:**
+```go
+arenaObj := astjson.ObjectValue(a)            // arena-allocated
+heapVal := astjson.StringValue(nil, "hello")  // heap-allocated
+arenaObj.Set(a, "key", heapVal)               // UNSAFE: GC can't see this ref
+heapVal = nil                                 // GC may collect it
+```
+
+**Safe — use DeepCopy:**
+```go
+arenaObj := astjson.ObjectValue(a)
+heapVal := astjson.StringValue(nil, "hello")
+arenaObj.Set(a, "key", astjson.DeepCopy(a, heapVal))  // safe: copy lives in arena
+```
+
+**Also safe — all values from the same arena:**
+```go
+arenaObj := astjson.ObjectValue(a)
+arenaVal := astjson.StringValue(a, "hello")
+arenaObj.Set(a, "key", arenaVal)  // safe: both on same arena
+```
+
+### Affected APIs
+
+These APIs store value pointers directly. When the container is arena-allocated,
+the value must also be arena-allocated (same arena) or a package-level singleton:
+
+  * `Object.Set` / `Value.Set` — stores the value argument directly
+  * `Value.SetArrayItem` — stores the value argument directly
+  * `AppendToArray` / `Value.AppendArrayItems` — stores elements directly
+  * `MergeValues` / `MergeValuesWithPath` — may store values from `b` into `a`
+
+Package-level singletons (`NullValue`, and the internal `valueTrue`, `valueFalse`,
+`valueNull`) are always safe because they are GC-visible global variables.
+
+### Arena lifetime
+
+Keep the arena alive for as long as any values allocated on it are in use.
+In performance-sensitive code where the compiler might not prove liveness,
+use `runtime.KeepAlive`:
+
+```go
+a := arena.NewMonotonicArena()
+v, _ := p.ParseWithArena(a, input)
+
+// ... use v ...
+result := v.MarshalTo(nil)
+
+runtime.KeepAlive(a) // ensure arena outlives all uses of v
+```
+
+### Don't mix arenas
+
+All values in a single tree should come from the same arena. If `MergeValues`
+returns a value from `b` and `a`/`b` were allocated on different arenas,
+resetting one arena while the other is still in use causes silent corruption.
+
+
+## Best Practices
+
+  * **One arena per unit of work.** Create an arena at the start of a request,
+    parse and build values on it, serialize the result, then let the arena be
+    collected. This gives you a clear, bounded lifetime.
+  * **Use `DeepCopy` at boundaries.** When inserting a value from an unknown
+    source (different arena, heap, parsed separately) into an arena container,
+    wrap it in `DeepCopy(a, val)`. This is a no-op when `a` is nil.
+  * **Prefer arena mode for hot paths.** Arena mode avoids per-Value heap
+    allocations, reducing GC pause time in high-throughput services.
+  * **Use heap mode for simplicity.** If GC pressure is not a concern, pass
+    `nil` for the arena. The GC handles all lifetimes and there are no mixing
+    pitfalls.
+  * **Don't share values across goroutines.** `Parser`, `Value`, `Object`, and
+    `Scanner` are not safe for concurrent use. Use per-goroutine instances.
+  * **Use `runtime.KeepAlive(arena)` when in doubt.** If there is any chance
+    the compiler could determine the arena is unused before you finish reading
+    values from it, add a `KeepAlive` call after the last use.
+  * **Deduplicate keys if merging from untrusted sources.**
+    `DeduplicateObjectKeysRecursively(v)` removes duplicate object keys
+    in place, keeping the first occurrence.
 
 
 ## Security
 
-  * `fastjson` shouldn't crash or panic when parsing input strings specially crafted
+  * `astjson` shouldn't crash or panic when parsing input strings specially crafted
     by an attacker. It must return error on invalid input JSON.
-  * `fastjson` requires up to `sizeof(Value) * len(inputJSON)` bytes of memory
+  * `astjson` requires up to `sizeof(Value) * len(inputJSON)` bytes of memory
     for parsing `inputJSON` string. Limit the maximum size of the `inputJSON`
     before parsing it in order to limit the maximum memory usage.
 
 
 ## Performance optimization tips
 
-  * Re-use [Parser](https://godoc.org/github.com/wundergraph/astjson#Parser) and [Scanner](https://godoc.org/github.com/wundergraph/astjson#Scanner)
-    for parsing many JSONs. This reduces memory allocations overhead.
-    [ParserPool](https://godoc.org/github.com/wundergraph/astjson#ParserPool) may be useful in this case.
-  * Prefer calling `Value.Get*` on the value returned from [Parser](https://godoc.org/github.com/wundergraph/astjson#Parser)
+  * Prefer calling `Value.Get*` on the value returned from `Parser`
     instead of calling `Get*` one-liners when multiple fields
     must be obtained from JSON, since each `Get*` one-liner re-parses
     the input JSON again.
-  * Prefer calling once [Value.Get](https://godoc.org/github.com/wundergraph/astjson#Value.Get)
-    for common prefix paths and then calling `Value.Get*` on the returned value
-    for distinct suffix paths.
-  * Prefer iterating over array returned from [Value.GetArray](https://godoc.org/github.com/wundergraph/astjson#Object.Visit)
+  * Prefer calling once `Value.Get` for common prefix paths and then calling
+    `Value.Get*` on the returned value for distinct suffix paths.
+  * Prefer iterating over the array returned from `Value.GetArray`
     with a range loop instead of calling `Value.Get*` for each array item.
 
 ## Fuzzing
@@ -202,24 +479,24 @@ BenchmarkValidate/twitter/fastjson       	    2000	   1036796 ns/op	 609.10 MB/s
     A: Because other packages require either rigid JSON schema via struct magic
        and code generation or perform poorly when multiple unrelated fields
        must be obtained from the parsed JSON.
-       Additionally, `fastjson` provides nicer [API](http://godoc.org/github.com/wundergraph/astjson).
+       Additionally, `astjson` provides nicer [API](http://godoc.org/github.com/wundergraph/astjson).
 
-  * Q: _What is the main purpose for `fastjson`?_
+  * Q: _What is the main purpose for `astjson`?_
     A: High-perf JSON parsing for [RTB](https://www.iab.com/wp-content/uploads/2015/05/OpenRTB_API_Specification_Version_2_3_1.pdf)
        and other [JSON-RPC](https://en.wikipedia.org/wiki/JSON-RPC) services.
 
-  * Q: _Why fastjson doesn't provide fast marshaling (serialization)?_
-    A: Actually it provides some sort of marshaling - see [Value.MarshalTo](https://godoc.org/github.com/wundergraph/astjson#Value.MarshalTo).
-       But I'd recommend using [quicktemplate](https://github.com/valyala/quicktemplate#use-cases)
-       for high-performance JSON marshaling :)
+  * Q: _Why doesn't astjson provide fast marshaling (serialization)?_
+    A: It provides `Value.MarshalTo` for serializing parsed/constructed JSON trees.
+       For high-performance templated JSON marshaling, consider
+       [quicktemplate](https://github.com/valyala/quicktemplate#use-cases).
 
-  * Q: _`fastjson` crashes my program!_
+  * Q: _`astjson` crashes my program!_
     A: There is high probability of improper use.
        * Make sure you don't hold references to objects recursively returned by `Parser` / `Scanner`
-         beyond the next `Parser.Parse` / `Scanner.Next` call
-         if such restriction is mentioned in [docs](https://github.com/wundergraph/astjson/issues/new).
-       * Make sure you don't access `fastjson` objects from concurrently running goroutines
-         if such restriction is mentioned in [docs](https://github.com/wundergraph/astjson/issues/new).
+         beyond the next `Parser.Parse` / `Scanner.Next` call.
+       * Make sure you don't access `astjson` objects from concurrently running goroutines.
+       * If using arena mode, read the [GC & Arena Safety](#gc--arena-safety) section carefully.
+         Mixing heap and arena values without `DeepCopy` causes silent use-after-free.
        * Build and run your program with [-race](https://golang.org/doc/articles/race_detector.html) flag.
          Make sure the race detector detects zero races.
-       * If your program continue crashing after fixing issues mentioned above, [file a bug](https://github.com/wundergraph/astjson/issues/new).
+       * If your program continues crashing after fixing the issues above, [file a bug](https://github.com/wundergraph/astjson/issues/new).

--- a/arena_gc_test.go
+++ b/arena_gc_test.go
@@ -1108,8 +1108,8 @@ func TestArenaGCSafety_ParseBytesWithArena_HeapInput(t *testing.T) {
 		if err != nil {
 			t.Fatalf("iteration %d: parse: %s", i, err)
 		}
-		// Drop reference to input
-		input = nil
+		// Drop reference to input so GC can collect the backing array
+		clear(input)
 		forceGC()
 
 		name := v.GetStringBytes("name")
@@ -1139,8 +1139,8 @@ func TestArenaGCSafety_StringValueBytes_HeapInput(t *testing.T) {
 		// Pass heap bytes directly — no manual arena copy
 		src := heapBytes("direct", i)
 		v := StringValueBytes(a, src)
-		// Drop reference to src
-		src = nil
+		// Drop reference to src so GC can collect the backing array
+		clear(src)
 		forceGC()
 		got := v.String()
 		expected := `"` + fmt.Sprintf("direct_%d_padding_to_ensure_heap_allocation", i) + `"`

--- a/arena_gc_test.go
+++ b/arena_gc_test.go
@@ -1318,6 +1318,22 @@ func TestArenaGCSafety_DeepCopy_NilValue(t *testing.T) {
 	runtime.KeepAlive(a)
 }
 
+// TestArenaGCSafety_DeepCopy_EmptyObject verifies that DeepCopy handles an
+// empty object (zero keys) without error.
+func TestArenaGCSafety_DeepCopy_EmptyObject(t *testing.T) {
+	a := arena.NewMonotonicArena()
+	obj := ObjectValue(a)
+	cp := DeepCopy(a, obj)
+	if cp.Type() != TypeObject {
+		t.Fatalf("expected TypeObject, got %v", cp.Type())
+	}
+	o, _ := cp.Object()
+	if o.Len() != 0 {
+		t.Fatalf("expected empty object, got %d keys", o.Len())
+	}
+	runtime.KeepAlive(a)
+}
+
 func TestArenaGCSafety_UnescapeAllBranches(t *testing.T) {
 	old := debug.SetGCPercent(1)
 	defer debug.SetGCPercent(old)

--- a/arena_gc_test.go
+++ b/arena_gc_test.go
@@ -1149,3 +1149,51 @@ func TestArenaGCSafety_StringValueBytes_HeapInput(t *testing.T) {
 		}
 	}
 }
+
+// TestArenaGCSafety_MixingHeapAndArenaValues_Demonstration documents the unsafe
+// pattern of storing a heap-allocated *Value into an arena-allocated container.
+//
+// Arena buffers are []byte allocations (noscan). The GC does not trace pointer
+// fields within arena memory. If a heap-allocated *Value is stored in an
+// arena-allocated []*kv or []*Value slice via Object.Set / SetArrayItem, and no
+// other GC-visible reference keeps that heap *Value alive, the GC may collect it.
+//
+// This test is skipped because it demonstrates undefined behavior that may or
+// may not manifest on a given run depending on GC timing and heap layout.
+func TestArenaGCSafety_MixingHeapAndArenaValues_Demonstration(t *testing.T) {
+	t.Skip("demonstrates unsafe heap/arena mixing — undefined behavior, not guaranteed to fail")
+
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+
+		// Arena-allocated container
+		obj := ObjectValue(a)
+
+		// Heap-allocated value (nil arena)
+		heapVal := StringValue(nil, heapString("unsafe", i))
+
+		// Store heap *Value into arena-allocated kv slice.
+		// The kv.v pointer lives inside a []byte buffer (noscan).
+		// The GC cannot see this reference.
+		obj.Set(a, "key", heapVal)
+
+		// Drop the only GC-visible reference to heapVal.
+		heapVal = nil //nolint:ineffassign
+
+		// Force GC — heapVal may be collected since the only reference
+		// to it is inside arena memory (noscan).
+		forceGC()
+
+		// This read may return corrupted data or crash if the GC
+		// collected the heap Value.
+		got := obj.Get("key")
+		expected := heapString("unsafe", i)
+		sb, _ := got.StringBytes()
+		if string(sb) != expected {
+			t.Fatalf("iteration %d: got %q, want %q (heap value may have been collected)", i, string(sb), expected)
+		}
+	}
+}

--- a/arena_gc_test.go
+++ b/arena_gc_test.go
@@ -1,0 +1,1007 @@
+package astjson
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"testing"
+
+	"github.com/wundergraph/go-arena"
+)
+
+// forceGC triggers aggressive garbage collection with heap pressure
+// to maximize the chance of collecting unreachable heap objects.
+func forceGC() {
+	// Allocate heap pressure to trigger GC
+	waste := make([][]byte, 100)
+	for i := range waste {
+		waste[i] = make([]byte, 1<<10)
+	}
+	runtime.GC()
+	runtime.GC()
+	runtime.KeepAlive(waste)
+}
+
+// heapString returns a heap-allocated string that has no other references.
+// The //go:noinline directive prevents the compiler from optimizing away
+// the allocation or keeping it on the stack.
+//
+//go:noinline
+func heapString(prefix string, i int) string {
+	return fmt.Sprintf("%s_%d_%s", prefix, i, "padding_to_ensure_heap_allocation")
+}
+
+// heapBytes returns a heap-allocated byte slice that has no other references.
+//
+//go:noinline
+func heapBytes(prefix string, i int) []byte {
+	return []byte(fmt.Sprintf("%s_%d_%s", prefix, i, "padding_to_ensure_heap_allocation"))
+}
+
+const gcTestIterations = 1000
+
+func TestArenaGCSafety_StringValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		s := heapString("hello", i)
+		v := StringValue(a, s)
+		forceGC()
+		got := v.String()
+		expected := `"` + s + `"`
+		if got != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestArenaGCSafety_IntValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		v := IntValue(a, i*12345)
+		forceGC()
+		got := v.String()
+		expected := strconv.Itoa(i * 12345)
+		if got != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestArenaGCSafety_FloatValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		f := 3.14159 * float64(i)
+		v := FloatValue(a, f)
+		forceGC()
+		got := v.String()
+		expected := strconv.FormatFloat(f, 'g', -1, 64)
+		if got != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestArenaGCSafety_NumberValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		s := heapString("42", i)
+		v := NumberValue(a, s)
+		forceGC()
+		got := v.String()
+		if got != s {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, s)
+		}
+	}
+}
+
+func TestArenaGCSafety_StringValueBytes(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		// Allocate the byte slice on the arena so it shares the arena's lifetime
+		src := heapBytes("bytes", i)
+		b := arena.AllocateSlice[byte](a, len(src), len(src))
+		copy(b, src)
+		v := StringValueBytes(a, b)
+		forceGC()
+		got := v.String()
+		expected := `"` + string(src) + `"`
+		if got != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestArenaGCSafety_TrueValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		v := TrueValue(a)
+		forceGC()
+		if v.Type() != TypeTrue {
+			t.Fatalf("iteration %d: expected TypeTrue, got %s", i, v.Type())
+		}
+		if v.String() != "true" {
+			t.Fatalf("iteration %d: got %q, want %q", i, v.String(), "true")
+		}
+	}
+}
+
+func TestArenaGCSafety_FalseValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		v := FalseValue(a)
+		forceGC()
+		if v.Type() != TypeFalse {
+			t.Fatalf("iteration %d: expected TypeFalse, got %s", i, v.Type())
+		}
+		if v.String() != "false" {
+			t.Fatalf("iteration %d: got %q, want %q", i, v.String(), "false")
+		}
+	}
+}
+
+func TestArenaGCSafety_ObjectValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		v := ObjectValue(a)
+		forceGC()
+		if v.Type() != TypeObject {
+			t.Fatalf("iteration %d: expected TypeObject, got %s", i, v.Type())
+		}
+		if v.String() != "{}" {
+			t.Fatalf("iteration %d: got %q, want %q", i, v.String(), "{}")
+		}
+	}
+}
+
+func TestArenaGCSafety_ArrayValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		v := ArrayValue(a)
+		forceGC()
+		if v.Type() != TypeArray {
+			t.Fatalf("iteration %d: expected TypeArray, got %s", i, v.Type())
+		}
+		if v.String() != "[]" {
+			t.Fatalf("iteration %d: got %q, want %q", i, v.String(), "[]")
+		}
+	}
+}
+
+func TestArenaGCSafety_ObjectSet(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		obj := ObjectValue(a)
+		key := heapString("key", i)
+		val := StringValue(a, heapString("val", i))
+		obj.Set(a, key, val)
+		forceGC()
+		got := string(obj.MarshalTo(nil))
+		expected := `{"` + key + `":"` + heapString("val", i) + `"}`
+		if got != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestArenaGCSafety_ValueSet(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		// Test on object
+		obj := ObjectValue(a)
+		key := heapString("key", i)
+		val := IntValue(a, i)
+		obj.Set(a, key, val)
+		forceGC()
+		result := obj.Get(key)
+		if result == nil {
+			t.Fatalf("iteration %d: expected non-nil result", i)
+		}
+		n, err := result.Int()
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %s", i, err)
+		}
+		if n != i {
+			t.Fatalf("iteration %d: got %d, want %d", i, n, i)
+		}
+
+		// Test on array
+		arr := ArrayValue(a)
+		arr.SetArrayItem(a, 0, IntValue(a, i*2))
+		forceGC()
+		n, err = arr.GetArray()[0].Int()
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected array error: %s", i, err)
+		}
+		if n != i*2 {
+			t.Fatalf("iteration %d: got %d, want %d", i, n, i*2)
+		}
+	}
+}
+
+func TestArenaGCSafety_SetArrayItem(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		arr := ArrayValue(a)
+		for j := 0; j < 5; j++ {
+			arr.SetArrayItem(a, j, IntValue(a, i*10+j))
+		}
+		forceGC()
+		items := arr.GetArray()
+		if len(items) != 5 {
+			t.Fatalf("iteration %d: expected 5 items, got %d", i, len(items))
+		}
+		for j := 0; j < 5; j++ {
+			n, err := items[j].Int()
+			if err != nil {
+				t.Fatalf("iteration %d, item %d: unexpected error: %s", i, j, err)
+			}
+			if n != i*10+j {
+				t.Fatalf("iteration %d, item %d: got %d, want %d", i, j, n, i*10+j)
+			}
+		}
+	}
+}
+
+func TestArenaGCSafety_AppendToArray(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		arr := ArrayValue(a)
+		for j := 0; j < 5; j++ {
+			AppendToArray(a, arr, StringValue(a, heapString("item", i*10+j)))
+		}
+		forceGC()
+		got := string(arr.MarshalTo(nil))
+		items := arr.GetArray()
+		if len(items) != 5 {
+			t.Fatalf("iteration %d: expected 5 items, got %d (output: %s)", i, len(items), got)
+		}
+		for j := 0; j < 5; j++ {
+			sb, err := items[j].StringBytes()
+			if err != nil {
+				t.Fatalf("iteration %d, item %d: unexpected error: %s", i, j, err)
+			}
+			expected := heapString("item", i*10+j)
+			if string(sb) != expected {
+				t.Fatalf("iteration %d, item %d: got %q, want %q", i, j, string(sb), expected)
+			}
+		}
+	}
+}
+
+func TestArenaGCSafety_AppendArrayItems(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		left := ArrayValue(a)
+		AppendToArray(a, left, IntValue(a, 1))
+		AppendToArray(a, left, IntValue(a, 2))
+
+		right := ArrayValue(a)
+		AppendToArray(a, right, IntValue(a, 3))
+		AppendToArray(a, right, IntValue(a, 4))
+
+		left.AppendArrayItems(a, right)
+		forceGC()
+
+		items := left.GetArray()
+		if len(items) != 4 {
+			t.Fatalf("iteration %d: expected 4 items, got %d", i, len(items))
+		}
+		for j, expected := range []int{1, 2, 3, 4} {
+			n, err := items[j].Int()
+			if err != nil {
+				t.Fatalf("iteration %d, item %d: unexpected error: %s", i, j, err)
+			}
+			if n != expected {
+				t.Fatalf("iteration %d, item %d: got %d, want %d", i, j, n, expected)
+			}
+		}
+	}
+}
+
+func TestArenaGCSafety_SetValue(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		obj := ObjectValue(a)
+		val := StringValue(a, heapString("deep_value", i))
+		SetValue(a, obj, val, "level1", "level2", "level3")
+		forceGC()
+		result := obj.Get("level1")
+		if result == nil {
+			t.Fatalf("iteration %d: level1 is nil", i)
+		}
+		result = result.Get("level2")
+		if result == nil {
+			t.Fatalf("iteration %d: level2 is nil", i)
+		}
+		result = result.Get("level3")
+		if result == nil {
+			t.Fatalf("iteration %d: level3 is nil", i)
+		}
+		sb, err := result.StringBytes()
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %s", i, err)
+		}
+		expected := heapString("deep_value", i)
+		if string(sb) != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, string(sb), expected)
+		}
+	}
+}
+
+func TestArenaGCSafety_SetNull(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		obj := ObjectValue(a)
+		obj.Set(a, "key", StringValue(a, heapString("value", i)))
+		SetNull(a, obj, "key")
+		forceGC()
+		result := obj.Get("key")
+		if result == nil {
+			t.Fatalf("iteration %d: expected non-nil result", i)
+		}
+		if result.Type() != TypeNull {
+			t.Fatalf("iteration %d: expected TypeNull, got %s", i, result.Type())
+		}
+		got := string(obj.MarshalTo(nil))
+		if got != `{"key":null}` {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, `{"key":null}`)
+		}
+	}
+}
+
+func TestArenaGCSafety_MergeValues(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		left, err := p.ParseWithArena(a, fmt.Sprintf(`{"a":"%d","b":"left"}`, i))
+		if err != nil {
+			t.Fatalf("iteration %d: parse left: %s", i, err)
+		}
+		right, err := p.ParseWithArena(a, fmt.Sprintf(`{"b":"right","c":"%d"}`, i))
+		if err != nil {
+			t.Fatalf("iteration %d: parse right: %s", i, err)
+		}
+		merged, _, err := MergeValues(a, left, right)
+		if err != nil {
+			t.Fatalf("iteration %d: merge: %s", i, err)
+		}
+		forceGC()
+		// Verify all keys survived GC
+		aVal := merged.Get("a")
+		if aVal == nil {
+			t.Fatalf("iteration %d: key 'a' is nil", i)
+		}
+		sb, _ := aVal.StringBytes()
+		if string(sb) != strconv.Itoa(i) {
+			t.Fatalf("iteration %d: key 'a' got %q, want %q", i, string(sb), strconv.Itoa(i))
+		}
+		bVal := merged.Get("b")
+		if bVal == nil {
+			t.Fatalf("iteration %d: key 'b' is nil", i)
+		}
+		sb, _ = bVal.StringBytes()
+		if string(sb) != "right" {
+			t.Fatalf("iteration %d: key 'b' got %q, want %q", i, string(sb), "right")
+		}
+		cVal := merged.Get("c")
+		if cVal == nil {
+			t.Fatalf("iteration %d: key 'c' is nil", i)
+		}
+		sb, _ = cVal.StringBytes()
+		if string(sb) != strconv.Itoa(i) {
+			t.Fatalf("iteration %d: key 'c' got %q, want %q", i, string(sb), strconv.Itoa(i))
+		}
+	}
+}
+
+func TestArenaGCSafety_MergeValuesWithPath(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		left, err := p.ParseWithArena(a, `{"data":{"existing":"value"}}`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse left: %s", i, err)
+		}
+		right := StringValue(a, heapString("merged", i))
+		merged, _, err := MergeValuesWithPath(a, left, right, "data", "nested")
+		if err != nil {
+			t.Fatalf("iteration %d: merge: %s", i, err)
+		}
+		forceGC()
+		result := merged.Get("data", "nested")
+		if result == nil {
+			t.Fatalf("iteration %d: nested result is nil", i)
+		}
+		sb, _ := result.StringBytes()
+		expected := heapString("merged", i)
+		if string(sb) != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, string(sb), expected)
+		}
+		// Verify existing data survived
+		existing := merged.Get("data", "existing")
+		if existing == nil {
+			t.Fatalf("iteration %d: existing is nil", i)
+		}
+		sb, _ = existing.StringBytes()
+		if string(sb) != "value" {
+			t.Fatalf("iteration %d: existing got %q, want %q", i, string(sb), "value")
+		}
+	}
+}
+
+func TestArenaGCSafety_ParseWithArena(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	jsonInput := `{
+		"name": "test",
+		"age": 42,
+		"score": 3.14,
+		"active": true,
+		"deleted": false,
+		"address": null,
+		"tags": ["go", "arena", "gc"],
+		"nested": {
+			"key": "value",
+			"count": 100
+		}
+	}`
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		v, err := p.ParseWithArena(a, jsonInput)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		forceGC()
+
+		// Exercise all read methods after GC
+
+		// Type
+		if v.Type() != TypeObject {
+			t.Fatalf("iteration %d: expected TypeObject, got %s", i, v.Type())
+		}
+
+		// Exists
+		if !v.Exists("name") {
+			t.Fatalf("iteration %d: name should exist", i)
+		}
+		if v.Exists("nonexistent") {
+			t.Fatalf("iteration %d: nonexistent should not exist", i)
+		}
+
+		// Get + StringBytes
+		name := v.Get("name")
+		if name == nil {
+			t.Fatalf("iteration %d: name is nil", i)
+		}
+		sb, err := name.StringBytes()
+		if err != nil {
+			t.Fatalf("iteration %d: StringBytes: %s", i, err)
+		}
+		if string(sb) != "test" {
+			t.Fatalf("iteration %d: name got %q, want %q", i, string(sb), "test")
+		}
+
+		// GetStringBytes
+		sb = v.GetStringBytes("name")
+		if string(sb) != "test" {
+			t.Fatalf("iteration %d: GetStringBytes got %q, want %q", i, string(sb), "test")
+		}
+
+		// GetInt
+		age := v.GetInt("age")
+		if age != 42 {
+			t.Fatalf("iteration %d: age got %d, want 42", i, age)
+		}
+
+		// Int
+		ageVal := v.Get("age")
+		ageInt, err := ageVal.Int()
+		if err != nil {
+			t.Fatalf("iteration %d: Int: %s", i, err)
+		}
+		if ageInt != 42 {
+			t.Fatalf("iteration %d: Int got %d, want 42", i, ageInt)
+		}
+
+		// GetFloat64
+		score := v.GetFloat64("score")
+		if score != 3.14 {
+			t.Fatalf("iteration %d: score got %f, want 3.14", i, score)
+		}
+
+		// Float64
+		scoreVal := v.Get("score")
+		scoreFloat, err := scoreVal.Float64()
+		if err != nil {
+			t.Fatalf("iteration %d: Float64: %s", i, err)
+		}
+		if scoreFloat != 3.14 {
+			t.Fatalf("iteration %d: Float64 got %f, want 3.14", i, scoreFloat)
+		}
+
+		// GetBool
+		active := v.GetBool("active")
+		if !active {
+			t.Fatalf("iteration %d: active should be true", i)
+		}
+
+		// Bool
+		activeVal := v.Get("active")
+		activeBool, err := activeVal.Bool()
+		if err != nil {
+			t.Fatalf("iteration %d: Bool: %s", i, err)
+		}
+		if !activeBool {
+			t.Fatalf("iteration %d: Bool should be true", i)
+		}
+
+		// GetArray
+		tags := v.GetArray("tags")
+		if len(tags) != 3 {
+			t.Fatalf("iteration %d: tags length got %d, want 3", i, len(tags))
+		}
+		tagBytes, _ := tags[0].StringBytes()
+		if string(tagBytes) != "go" {
+			t.Fatalf("iteration %d: first tag got %q, want %q", i, string(tagBytes), "go")
+		}
+
+		// Array
+		tagsVal := v.Get("tags")
+		tagsArr, err := tagsVal.Array()
+		if err != nil {
+			t.Fatalf("iteration %d: Array: %s", i, err)
+		}
+		if len(tagsArr) != 3 {
+			t.Fatalf("iteration %d: Array length got %d, want 3", i, len(tagsArr))
+		}
+
+		// GetObject
+		nested := v.GetObject("nested")
+		if nested == nil {
+			t.Fatalf("iteration %d: nested is nil", i)
+		}
+		if nested.Len() != 2 {
+			t.Fatalf("iteration %d: nested length got %d, want 2", i, nested.Len())
+		}
+
+		// Object
+		obj, err := v.Object()
+		if err != nil {
+			t.Fatalf("iteration %d: Object: %s", i, err)
+		}
+
+		// Object.Len
+		if obj.Len() != 8 {
+			t.Fatalf("iteration %d: object length got %d, want 8", i, obj.Len())
+		}
+
+		// Object.Get
+		nameFromObj := obj.Get("name")
+		if nameFromObj == nil {
+			t.Fatalf("iteration %d: Object.Get name is nil", i)
+		}
+
+		// Object.Visit
+		keyCount := 0
+		obj.Visit(func(key []byte, val *Value) {
+			keyCount++
+			if len(key) == 0 {
+				t.Fatalf("iteration %d: empty key in Visit", i)
+			}
+		})
+		if keyCount != 8 {
+			t.Fatalf("iteration %d: Visit counted %d keys, want 8", i, keyCount)
+		}
+
+		// MarshalTo + String
+		marshaled := string(v.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+		str := v.String()
+		if str != marshaled {
+			t.Fatalf("iteration %d: String() != MarshalTo()", i)
+		}
+
+		// Uint, Int64, Uint64 on number value
+		ageUint, err := ageVal.Uint()
+		if err != nil {
+			t.Fatalf("iteration %d: Uint: %s", i, err)
+		}
+		if ageUint != 42 {
+			t.Fatalf("iteration %d: Uint got %d, want 42", i, ageUint)
+		}
+		ageInt64, err := ageVal.Int64()
+		if err != nil {
+			t.Fatalf("iteration %d: Int64: %s", i, err)
+		}
+		if ageInt64 != 42 {
+			t.Fatalf("iteration %d: Int64 got %d, want 42", i, ageInt64)
+		}
+		ageUint64, err := ageVal.Uint64()
+		if err != nil {
+			t.Fatalf("iteration %d: Uint64: %s", i, err)
+		}
+		if ageUint64 != 42 {
+			t.Fatalf("iteration %d: Uint64 got %d, want 42", i, ageUint64)
+		}
+
+		// GetUint, GetInt64, GetUint64
+		if v.GetUint("age") != 42 {
+			t.Fatalf("iteration %d: GetUint got %d, want 42", i, v.GetUint("age"))
+		}
+		if v.GetInt64("age") != 42 {
+			t.Fatalf("iteration %d: GetInt64 got %d, want 42", i, v.GetInt64("age"))
+		}
+		if v.GetUint64("age") != 42 {
+			t.Fatalf("iteration %d: GetUint64 got %d, want 42", i, v.GetUint64("age"))
+		}
+	}
+}
+
+func TestArenaGCSafety_ParseBytesWithArena(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	jsonInput := []byte(`{"key":"value","num":123,"arr":[1,2,3]}`)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		// Copy input to arena-allocated buffer
+		buf := arena.AllocateSlice[byte](a, len(jsonInput), len(jsonInput))
+		copy(buf, jsonInput)
+		var p Parser
+		v, err := p.ParseBytesWithArena(a, buf)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		forceGC()
+		got := string(v.MarshalTo(nil))
+		expected := `{"key":"value","num":123,"arr":[1,2,3]}`
+		if got != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestArenaGCSafety_ObjectDel(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		v, err := p.ParseWithArena(a, `{"keep":"yes","remove":"no","also_keep":"yes"}`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		o, _ := v.Object()
+		o.Del("remove")
+		forceGC()
+		if o.Len() != 2 {
+			t.Fatalf("iteration %d: expected 2 keys, got %d", i, o.Len())
+		}
+		if o.Get("keep") == nil {
+			t.Fatalf("iteration %d: 'keep' should exist", i)
+		}
+		if o.Get("also_keep") == nil {
+			t.Fatalf("iteration %d: 'also_keep' should exist", i)
+		}
+	}
+}
+
+func TestArenaGCSafety_ValueDel(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		// Test del on array
+		v, err := p.ParseWithArena(a, `[1,2,3,4,5]`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		v.Del("2") // Remove middle element
+		forceGC()
+		items := v.GetArray()
+		if len(items) != 4 {
+			t.Fatalf("iteration %d: expected 4 items, got %d", i, len(items))
+		}
+
+		// Test del on object
+		v2, err := p.ParseWithArena(a, `{"a":1,"b":2}`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse v2: %s", i, err)
+		}
+		v2.Del("a")
+		forceGC()
+		if v2.GetObject().Len() != 1 {
+			t.Fatalf("iteration %d: expected 1 key, got %d", i, v2.GetObject().Len())
+		}
+	}
+}
+
+func TestArenaGCSafety_DeduplicateObjectKeysRecursively(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		v, err := p.ParseWithArena(a, `{"a":1,"b":2,"a":3,"nested":{"x":1,"x":2}}`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		DeduplicateObjectKeysRecursively(v)
+		forceGC()
+		o, _ := v.Object()
+		if o.Len() != 3 {
+			t.Fatalf("iteration %d: expected 3 keys after dedup, got %d", i, o.Len())
+		}
+		nested := v.GetObject("nested")
+		if nested == nil {
+			t.Fatalf("iteration %d: nested is nil", i)
+		}
+		if nested.Len() != 1 {
+			t.Fatalf("iteration %d: nested expected 1 key after dedup, got %d", i, nested.Len())
+		}
+	}
+}
+
+func TestArenaGCSafety_ValueIsNull(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		null := arena.Allocate[Value](a)
+		null.t = TypeNull
+		nonNull := StringValue(a, heapString("notnull", i))
+		forceGC()
+		if !ValueIsNull(null) {
+			t.Fatalf("iteration %d: expected null to be null", i)
+		}
+		if ValueIsNull(nonNull) {
+			t.Fatalf("iteration %d: expected nonNull to not be null", i)
+		}
+		if ValueIsNonNull(null) {
+			t.Fatalf("iteration %d: expected null to not be non-null", i)
+		}
+		if !ValueIsNonNull(nonNull) {
+			t.Fatalf("iteration %d: expected nonNull to be non-null", i)
+		}
+	}
+}
+
+func TestArenaGCSafety_ParseWithArena_EscapedKeys(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	// Test that keys with escape sequences are properly arena-allocated during parsing
+	jsonInput := `{"normal":"a","escaped\tkey":"b","unicode\u0041key":"c"}`
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		v, err := p.ParseWithArena(a, jsonInput)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		forceGC()
+
+		// Normal key
+		normal := v.Get("normal")
+		if normal == nil {
+			t.Fatalf("iteration %d: normal is nil", i)
+		}
+
+		// Escaped key (tab)
+		escaped := v.Get("escaped\tkey")
+		if escaped == nil {
+			t.Fatalf("iteration %d: escaped tab key is nil", i)
+		}
+		sb, _ := escaped.StringBytes()
+		if string(sb) != "b" {
+			t.Fatalf("iteration %d: escaped key value got %q, want %q", i, string(sb), "b")
+		}
+
+		// Unicode escape key
+		unicode := v.Get("unicodeAkey")
+		if unicode == nil {
+			t.Fatalf("iteration %d: unicode key is nil", i)
+		}
+		sb, _ = unicode.StringBytes()
+		if string(sb) != "c" {
+			t.Fatalf("iteration %d: unicode key value got %q, want %q", i, string(sb), "c")
+		}
+
+		// Verify marshaling round-trip
+		marshaled := string(v.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+	}
+}
+
+func TestArenaGCSafety_ParseWithArena_EscapedStrings(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	// Test that string values with escape sequences are properly arena-allocated
+	jsonInput := `{"a":"hello\tworld","b":"line1\nline2","c":"quote\"inside","d":"unicode\u0041"}`
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		v, err := p.ParseWithArena(a, jsonInput)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		forceGC()
+
+		tests := map[string]string{
+			"a": "hello\tworld",
+			"b": "line1\nline2",
+			"c": "quote\"inside",
+			"d": "unicodeA",
+		}
+		for key, expected := range tests {
+			val := v.Get(key)
+			if val == nil {
+				t.Fatalf("iteration %d: key %q is nil", i, key)
+			}
+			sb, err := val.StringBytes()
+			if err != nil {
+				t.Fatalf("iteration %d: key %q StringBytes: %s", i, key, err)
+			}
+			if string(sb) != expected {
+				t.Fatalf("iteration %d: key %q got %q, want %q", i, key, string(sb), expected)
+			}
+		}
+	}
+}
+
+func TestArenaGCSafety_ComplexWorkflow(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	// Simulate a realistic workflow: parse, modify, merge, marshal
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		// Parse base document
+		base, err := p.ParseWithArena(a, `{"users":[{"name":"alice","age":30}],"count":1}`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse base: %s", i, err)
+		}
+
+		// Create a new user and append to array
+		newUser := ObjectValue(a)
+		newUser.Set(a, "name", StringValue(a, heapString("bob", i)))
+		newUser.Set(a, "age", IntValue(a, 25+i))
+		users := base.Get("users")
+		AppendToArray(a, users, newUser)
+
+		// Update count
+		base.Set(a, "count", IntValue(a, 2))
+
+		// Merge with additional data
+		extra, err := p.ParseWithArena(a, `{"metadata":{"version":"1.0"}}`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse extra: %s", i, err)
+		}
+		merged, _, err := MergeValues(a, base, extra)
+		if err != nil {
+			t.Fatalf("iteration %d: merge: %s", i, err)
+		}
+
+		forceGC()
+
+		// Verify everything survived GC
+		usersArr := merged.GetArray("users")
+		if len(usersArr) != 2 {
+			t.Fatalf("iteration %d: expected 2 users, got %d", i, len(usersArr))
+		}
+
+		// Verify first user
+		alice := usersArr[0]
+		aliceName, _ := alice.Get("name").StringBytes()
+		if string(aliceName) != "alice" {
+			t.Fatalf("iteration %d: first user name got %q, want %q", i, string(aliceName), "alice")
+		}
+
+		// Verify second user (heap-allocated name)
+		bob := usersArr[1]
+		bobName, _ := bob.Get("name").StringBytes()
+		expected := heapString("bob", i)
+		if string(bobName) != expected {
+			t.Fatalf("iteration %d: second user name got %q, want %q", i, string(bobName), expected)
+		}
+		bobAge, _ := bob.Get("age").Int()
+		if bobAge != 25+i {
+			t.Fatalf("iteration %d: bob age got %d, want %d", i, bobAge, 25+i)
+		}
+
+		// Verify count
+		count, _ := merged.Get("count").Int()
+		if count != 2 {
+			t.Fatalf("iteration %d: count got %d, want 2", i, count)
+		}
+
+		// Verify merged metadata
+		version := merged.Get("metadata", "version")
+		if version == nil {
+			t.Fatalf("iteration %d: metadata.version is nil", i)
+		}
+		vb, _ := version.StringBytes()
+		if string(vb) != "1.0" {
+			t.Fatalf("iteration %d: version got %q, want %q", i, string(vb), "1.0")
+		}
+
+		// Final marshal to verify integrity
+		marshaled := string(merged.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+	}
+}

--- a/arena_gc_test.go
+++ b/arena_gc_test.go
@@ -55,6 +55,7 @@ func TestArenaGCSafety_StringValue(t *testing.T) {
 		if got != expected {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -71,6 +72,7 @@ func TestArenaGCSafety_IntValue(t *testing.T) {
 		if got != expected {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -88,6 +90,7 @@ func TestArenaGCSafety_FloatValue(t *testing.T) {
 		if got != expected {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -104,6 +107,7 @@ func TestArenaGCSafety_NumberValue(t *testing.T) {
 		if got != s {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, s)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -124,6 +128,7 @@ func TestArenaGCSafety_StringValueBytes(t *testing.T) {
 		if got != expected {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -141,6 +146,7 @@ func TestArenaGCSafety_TrueValue(t *testing.T) {
 		if v.String() != "true" {
 			t.Fatalf("iteration %d: got %q, want %q", i, v.String(), "true")
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -158,6 +164,7 @@ func TestArenaGCSafety_FalseValue(t *testing.T) {
 		if v.String() != "false" {
 			t.Fatalf("iteration %d: got %q, want %q", i, v.String(), "false")
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -175,6 +182,7 @@ func TestArenaGCSafety_ObjectValue(t *testing.T) {
 		if v.String() != "{}" {
 			t.Fatalf("iteration %d: got %q, want %q", i, v.String(), "{}")
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -192,6 +200,7 @@ func TestArenaGCSafety_ArrayValue(t *testing.T) {
 		if v.String() != "[]" {
 			t.Fatalf("iteration %d: got %q, want %q", i, v.String(), "[]")
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -211,6 +220,7 @@ func TestArenaGCSafety_ObjectSet(t *testing.T) {
 		if got != expected {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -249,6 +259,7 @@ func TestArenaGCSafety_ValueSet(t *testing.T) {
 		if n != i*2 {
 			t.Fatalf("iteration %d: got %d, want %d", i, n, i*2)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -276,6 +287,7 @@ func TestArenaGCSafety_SetArrayItem(t *testing.T) {
 				t.Fatalf("iteration %d, item %d: got %d, want %d", i, j, n, i*10+j)
 			}
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -305,6 +317,7 @@ func TestArenaGCSafety_AppendToArray(t *testing.T) {
 				t.Fatalf("iteration %d, item %d: got %q, want %q", i, j, string(sb), expected)
 			}
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -338,6 +351,7 @@ func TestArenaGCSafety_AppendArrayItems(t *testing.T) {
 				t.Fatalf("iteration %d, item %d: got %d, want %d", i, j, n, expected)
 			}
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -371,6 +385,7 @@ func TestArenaGCSafety_SetValue(t *testing.T) {
 		if string(sb) != expected {
 			t.Fatalf("iteration %d: got %q, want %q", i, string(sb), expected)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -395,6 +410,7 @@ func TestArenaGCSafety_SetNull(t *testing.T) {
 		if got != `{"key":null}` {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, `{"key":null}`)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -443,6 +459,7 @@ func TestArenaGCSafety_MergeValues(t *testing.T) {
 		if string(sb) != strconv.Itoa(i) {
 			t.Fatalf("iteration %d: key 'c' got %q, want %q", i, string(sb), strconv.Itoa(i))
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -481,6 +498,7 @@ func TestArenaGCSafety_MergeValuesWithPath(t *testing.T) {
 		if string(sb) != "value" {
 			t.Fatalf("iteration %d: existing got %q, want %q", i, string(sb), "value")
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -694,6 +712,7 @@ func TestArenaGCSafety_ParseWithArena(t *testing.T) {
 		if v.GetUint64("age") != 42 {
 			t.Fatalf("iteration %d: GetUint64 got %d, want 42", i, v.GetUint64("age"))
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -719,6 +738,7 @@ func TestArenaGCSafety_ParseBytesWithArena(t *testing.T) {
 		if got != expected {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -745,6 +765,7 @@ func TestArenaGCSafety_ObjectDel(t *testing.T) {
 		if o.Get("also_keep") == nil {
 			t.Fatalf("iteration %d: 'also_keep' should exist", i)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -777,6 +798,7 @@ func TestArenaGCSafety_ValueDel(t *testing.T) {
 		if v2.GetObject().Len() != 1 {
 			t.Fatalf("iteration %d: expected 1 key, got %d", i, v2.GetObject().Len())
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -804,6 +826,7 @@ func TestArenaGCSafety_DeduplicateObjectKeysRecursively(t *testing.T) {
 		if nested.Len() != 1 {
 			t.Fatalf("iteration %d: nested expected 1 key after dedup, got %d", i, nested.Len())
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -829,6 +852,7 @@ func TestArenaGCSafety_ValueIsNull(t *testing.T) {
 		if !ValueIsNonNull(nonNull) {
 			t.Fatalf("iteration %d: expected nonNull to be non-null", i)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -879,6 +903,7 @@ func TestArenaGCSafety_ParseWithArena_EscapedKeys(t *testing.T) {
 		if len(marshaled) == 0 {
 			t.Fatalf("iteration %d: MarshalTo returned empty", i)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -917,6 +942,7 @@ func TestArenaGCSafety_ParseWithArena_EscapedStrings(t *testing.T) {
 				t.Fatalf("iteration %d: key %q got %q, want %q", i, key, string(sb), expected)
 			}
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -1003,6 +1029,7 @@ func TestArenaGCSafety_ComplexWorkflow(t *testing.T) {
 		if len(marshaled) == 0 {
 			t.Fatalf("iteration %d: MarshalTo returned empty", i)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -1090,6 +1117,7 @@ func TestArenaGCSafety_ParseWithArena_HeapInput(t *testing.T) {
 		if len(marshaled) == 0 {
 			t.Fatalf("iteration %d: MarshalTo returned empty", i)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -1125,6 +1153,7 @@ func TestArenaGCSafety_ParseBytesWithArena_HeapInput(t *testing.T) {
 		if len(marshaled) == 0 {
 			t.Fatalf("iteration %d: MarshalTo returned empty", i)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -1147,6 +1176,7 @@ func TestArenaGCSafety_StringValueBytes_HeapInput(t *testing.T) {
 		if got != expected {
 			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
 		}
+		runtime.KeepAlive(a)
 	}
 }
 
@@ -1195,5 +1225,549 @@ func TestArenaGCSafety_MixingHeapAndArenaValues_Demonstration(t *testing.T) {
 		if string(sb) != expected {
 			t.Fatalf("iteration %d: got %q, want %q (heap value may have been collected)", i, string(sb), expected)
 		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_UnescapeAllBranches(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	// JSON exercises every branch of unescapeStringBestEffort:
+	// simple escapes: \\ \/ \b \f \r \t \n \"
+	// unicode non-surrogate: \u0041 (A)
+	// surrogate pair: \uD83D\uDE00 (😀)
+	// lone high surrogate (no low follows): \uD800X
+	// unknown escape: \x
+	jsonInput := `{
+		"backslash": "a\\b",
+		"slash": "a\/b",
+		"backspace": "a\bb",
+		"formfeed": "a\fb",
+		"carriage": "a\rb",
+		"tab": "a\tb",
+		"newline": "a\nb",
+		"quote": "a\"b",
+		"unicode": "\u0041\u0042\u0043",
+		"surrogate": "\uD83D\uDE00",
+		"lone_surrogate": "\uD800X",
+		"unknown_esc": "\x",
+		"mixed": "a\tb\nc\\d\u0041"
+	}`
+
+	expected := map[string]string{
+		"backslash":      "a\\b",
+		"slash":          "a/b",
+		"backspace":      "a\bb",
+		"formfeed":       "a\fb",
+		"carriage":       "a\rb",
+		"tab":            "a\tb",
+		"newline":        "a\nb",
+		"quote":          "a\"b",
+		"unicode":        "ABC",
+		"surrogate":      "😀",
+		"lone_surrogate": "\\uD800X",
+		"unknown_esc":    "\\x",
+		"mixed":          "a\tb\nc\\dA",
+	}
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		v, err := p.ParseWithArena(a, jsonInput)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		forceGC()
+
+		for key, want := range expected {
+			got := v.Get(key)
+			if got == nil {
+				t.Fatalf("iteration %d: key %q is nil", i, key)
+			}
+			sb, err := got.StringBytes()
+			if err != nil {
+				t.Fatalf("iteration %d: key %q StringBytes: %s", i, key, err)
+			}
+			if string(sb) != want {
+				t.Fatalf("iteration %d: key %q got %q, want %q", i, key, string(sb), want)
+			}
+		}
+
+		marshaled := string(v.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_MergeValues_ScalarReplacement(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		left, err := p.ParseWithArena(a, fmt.Sprintf(`{"n":%d,"s":"old_%d","b":true}`, i, i))
+		if err != nil {
+			t.Fatalf("iteration %d: parse left: %s", i, err)
+		}
+		right, err := p.ParseWithArena(a, fmt.Sprintf(`{"n":%d,"s":"new_%d","b":false}`, i+1000, i))
+		if err != nil {
+			t.Fatalf("iteration %d: parse right: %s", i, err)
+		}
+		merged, _, err := MergeValues(a, left, right)
+		if err != nil {
+			t.Fatalf("iteration %d: merge: %s", i, err)
+		}
+		forceGC()
+
+		n, _ := merged.Get("n").Float64()
+		if n != float64(i+1000) {
+			t.Fatalf("iteration %d: number got %v, want %v", i, n, i+1000)
+		}
+
+		sb, _ := merged.Get("s").StringBytes()
+		expectedStr := fmt.Sprintf("new_%d", i)
+		if string(sb) != expectedStr {
+			t.Fatalf("iteration %d: string got %q, want %q", i, string(sb), expectedStr)
+		}
+
+		bVal := merged.Get("b")
+		if bVal.Type() != TypeFalse {
+			t.Fatalf("iteration %d: bool got %s, want TypeFalse", i, bVal.Type())
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_MergeValues_RecursiveObjects(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		leftJSON := fmt.Sprintf(`{"a":{"x":%d,"y":"old_%d"},"b":{"m":"keep"}}`, i, i)
+		rightJSON := fmt.Sprintf(`{"a":{"y":"new_%d","z":%d},"b":{"n":"added"}}`, i, i*10)
+
+		left, err := p.ParseWithArena(a, leftJSON)
+		if err != nil {
+			t.Fatalf("iteration %d: parse left: %s", i, err)
+		}
+		right, err := p.ParseWithArena(a, rightJSON)
+		if err != nil {
+			t.Fatalf("iteration %d: parse right: %s", i, err)
+		}
+		merged, _, err := MergeValues(a, left, right)
+		if err != nil {
+			t.Fatalf("iteration %d: merge: %s", i, err)
+		}
+		forceGC()
+
+		aObj := merged.Get("a")
+		if aObj == nil {
+			t.Fatalf("iteration %d: key 'a' is nil", i)
+		}
+		x, _ := aObj.Get("x").Int()
+		if x != i {
+			t.Fatalf("iteration %d: a.x got %d, want %d", i, x, i)
+		}
+		yb, _ := aObj.Get("y").StringBytes()
+		expectedY := fmt.Sprintf("new_%d", i)
+		if string(yb) != expectedY {
+			t.Fatalf("iteration %d: a.y got %q, want %q", i, string(yb), expectedY)
+		}
+		z, _ := aObj.Get("z").Int()
+		if z != i*10 {
+			t.Fatalf("iteration %d: a.z got %d, want %d", i, z, i*10)
+		}
+
+		bObj := merged.Get("b")
+		mb, _ := bObj.Get("m").StringBytes()
+		if string(mb) != "keep" {
+			t.Fatalf("iteration %d: b.m got %q, want %q", i, string(mb), "keep")
+		}
+		nb, _ := bObj.Get("n").StringBytes()
+		if string(nb) != "added" {
+			t.Fatalf("iteration %d: b.n got %q, want %q", i, string(nb), "added")
+		}
+
+		marshaled := string(merged.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_MergeValues_EmptyArrays(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		left, err := p.ParseWithArena(a, `[]`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse left: %s", i, err)
+		}
+		right, err := p.ParseWithArena(a, fmt.Sprintf(`[%d,%d,%d]`, i, i+1, i+2))
+		if err != nil {
+			t.Fatalf("iteration %d: parse right: %s", i, err)
+		}
+		merged, changed, err := MergeValues(a, left, right)
+		if err != nil {
+			t.Fatalf("iteration %d: merge empty+full: %s", i, err)
+		}
+		if !changed {
+			t.Fatalf("iteration %d: expected changed=true for empty left", i)
+		}
+		forceGC()
+		arr := merged.GetArray()
+		if len(arr) != 3 {
+			t.Fatalf("iteration %d: expected 3 items, got %d", i, len(arr))
+		}
+		n, _ := arr[0].Int()
+		if n != i {
+			t.Fatalf("iteration %d: arr[0] got %d, want %d", i, n, i)
+		}
+
+		left2, err := p.ParseWithArena(a, fmt.Sprintf(`[%d,%d]`, i*10, i*10+1))
+		if err != nil {
+			t.Fatalf("iteration %d: parse left2: %s", i, err)
+		}
+		right2, err := p.ParseWithArena(a, `[]`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse right2: %s", i, err)
+		}
+		merged2, changed2, err := MergeValues(a, left2, right2)
+		if err != nil {
+			t.Fatalf("iteration %d: merge full+empty: %s", i, err)
+		}
+		if changed2 {
+			t.Fatalf("iteration %d: expected changed=false for empty right", i)
+		}
+		forceGC()
+		arr2 := merged2.GetArray()
+		if len(arr2) != 2 {
+			t.Fatalf("iteration %d: expected 2 items, got %d", i, len(arr2))
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_MergeValues_NullHandling(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		left, err := p.ParseWithArena(a, fmt.Sprintf(`{"nested":{"val":%d}}`, i))
+		if err != nil {
+			t.Fatalf("iteration %d: parse left: %s", i, err)
+		}
+		right, err := p.ParseWithArena(a, `null`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse right: %s", i, err)
+		}
+		merged, changed, err := MergeValues(a, left, right)
+		if err != nil {
+			t.Fatalf("iteration %d: merge: %s", i, err)
+		}
+		if changed {
+			t.Fatalf("iteration %d: expected changed=false for null right on object left", i)
+		}
+		forceGC()
+
+		nested := merged.Get("nested")
+		if nested == nil {
+			t.Fatalf("iteration %d: nested is nil", i)
+		}
+		val, _ := nested.Get("val").Int()
+		if val != i {
+			t.Fatalf("iteration %d: nested.val got %d, want %d", i, val, i)
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_ArenaBufferGrowth(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	const iterations = 100
+
+	for i := 0; i < iterations; i++ {
+		// Use a small buffer size to force multiple arena buffers
+		a := arena.NewMonotonicArena(arena.WithMinBufferSize(1024))
+		var p Parser
+
+		buf := []byte(`[`)
+		for j := 0; j < 200; j++ {
+			if j > 0 {
+				buf = append(buf, ',')
+			}
+			entry := fmt.Sprintf(`{"id":%d,"name":"item_%d_%d","value":"val_%d_%d_padding_to_increase_size"}`,
+				j, i, j, i, j)
+			buf = append(buf, entry...)
+		}
+		buf = append(buf, ']')
+
+		v, err := p.ParseBytesWithArena(a, buf)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		buf = nil
+		forceGC()
+
+		arr := v.GetArray()
+		if len(arr) != 200 {
+			t.Fatalf("iteration %d: expected 200 items, got %d", i, len(arr))
+		}
+
+		for _, idx := range []int{0, 1, 50, 99, 150, 199} {
+			elem := arr[idx]
+			id, _ := elem.Get("id").Int()
+			if id != idx {
+				t.Fatalf("iteration %d: arr[%d].id got %d, want %d", i, idx, id, idx)
+			}
+			name, _ := elem.Get("name").StringBytes()
+			expectedName := fmt.Sprintf("item_%d_%d", i, idx)
+			if string(name) != expectedName {
+				t.Fatalf("iteration %d: arr[%d].name got %q, want %q", i, idx, string(name), expectedName)
+			}
+		}
+
+		marshaled := v.MarshalTo(nil)
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_ObjectSet_Overwrite(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		obj := ObjectValue(a)
+
+		key := heapString("key", i)
+		firstVal := StringValue(a, heapString("first", i))
+		obj.Set(a, key, firstVal)
+
+		secondVal := StringValue(a, heapString("second", i))
+		obj.Set(a, key, secondVal)
+
+		forceGC()
+
+		got := obj.Get(key)
+		if got == nil {
+			t.Fatalf("iteration %d: key not found after overwrite", i)
+		}
+		sb, _ := got.StringBytes()
+		expected := heapString("second", i)
+		if string(sb) != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, string(sb), expected)
+		}
+
+		o, _ := obj.Object()
+		if o.Len() != 1 {
+			t.Fatalf("iteration %d: expected 1 key, got %d", i, o.Len())
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_NaNInf(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"NaN", "NaN"},
+		{"nan", "nan"},
+		{"Inf", "Inf"},
+		{"-Inf", "-Inf"},
+		{"+Inf", "+Inf"},
+	}
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		for _, tc := range cases {
+			v, err := p.ParseWithArena(a, tc.input)
+			if err != nil {
+				t.Fatalf("iteration %d: parse %q: %s", i, tc.input, err)
+			}
+			forceGC()
+
+			if v.Type() != TypeNumber {
+				t.Fatalf("iteration %d: %q type got %s, want TypeNumber", i, tc.input, v.Type())
+			}
+			got := v.String()
+			if got != tc.want {
+				t.Fatalf("iteration %d: %q String() got %q, want %q", i, tc.input, got, tc.want)
+			}
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_EmptyStringValues(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		v, err := p.ParseWithArena(a, `{"empty":"","arr":["",""],"nested":{"also_empty":""}}`)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		forceGC()
+
+		sb, _ := v.Get("empty").StringBytes()
+		if len(sb) != 0 {
+			t.Fatalf("iteration %d: empty got %q, want empty", i, string(sb))
+		}
+
+		arr := v.GetArray("arr")
+		if len(arr) != 2 {
+			t.Fatalf("iteration %d: arr length got %d, want 2", i, len(arr))
+		}
+		for j, elem := range arr {
+			sb, _ := elem.StringBytes()
+			if len(sb) != 0 {
+				t.Fatalf("iteration %d: arr[%d] got %q, want empty", i, j, string(sb))
+			}
+		}
+
+		sb, _ = v.Get("nested", "also_empty").StringBytes()
+		if len(sb) != 0 {
+			t.Fatalf("iteration %d: nested.also_empty got %q, want empty", i, string(sb))
+		}
+
+		got := string(v.MarshalTo(nil))
+		expected := `{"empty":"","arr":["",""],"nested":{"also_empty":""}}`
+		if got != expected {
+			t.Fatalf("iteration %d: marshal got %q, want %q", i, got, expected)
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+//go:noinline
+func buildLargeEscapedJSON(i int) string {
+	s := `{"escaped":"`
+	for j := 0; j < 100; j++ {
+		s += fmt.Sprintf(`\t\n\r\\\/\b\f\u00%02X`, 0x41+(j%26))
+	}
+	s += fmt.Sprintf(`_%d"}`, i)
+	return s
+}
+
+func TestArenaGCSafety_LargeEscapedStrings(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		input := buildLargeEscapedJSON(i)
+		v, err := p.ParseWithArena(a, input)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		input = ""
+		_ = input
+		forceGC()
+
+		val := v.Get("escaped")
+		if val == nil {
+			t.Fatalf("iteration %d: escaped is nil", i)
+		}
+		sb, _ := val.StringBytes()
+		suffix := fmt.Sprintf("_%d", i)
+		if len(sb) == 0 || string(sb[len(sb)-len(suffix):]) != suffix {
+			t.Fatalf("iteration %d: string doesn't end with %q", i, suffix)
+		}
+		if len(sb) < 100 {
+			t.Fatalf("iteration %d: decoded string too short: %d", i, len(sb))
+		}
+
+		marshaled := string(v.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+func TestArenaGCSafety_ManyObjectKeys(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	const iterations = 200
+	const numKeys = 200
+
+	for i := 0; i < iterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+
+		buf := []byte(`{`)
+		for j := 0; j < numKeys; j++ {
+			if j > 0 {
+				buf = append(buf, ',')
+			}
+			entry := fmt.Sprintf(`"key_%d_%d":"val_%d_%d"`, i, j, i, j)
+			buf = append(buf, entry...)
+		}
+		buf = append(buf, '}')
+
+		v, err := p.ParseBytesWithArena(a, buf)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		buf = nil
+		forceGC()
+
+		o, _ := v.Object()
+		if o.Len() != numKeys {
+			t.Fatalf("iteration %d: expected %d keys, got %d", i, numKeys, o.Len())
+		}
+
+		for _, idx := range []int{0, 1, 50, 99, 150, 199} {
+			key := fmt.Sprintf("key_%d_%d", i, idx)
+			val := v.Get(key)
+			if val == nil {
+				t.Fatalf("iteration %d: key %q is nil", i, key)
+			}
+			sb, _ := val.StringBytes()
+			expected := fmt.Sprintf("val_%d_%d", i, idx)
+			if string(sb) != expected {
+				t.Fatalf("iteration %d: key %q got %q, want %q", i, key, string(sb), expected)
+			}
+		}
+
+		marshaled := v.MarshalTo(nil)
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+		runtime.KeepAlive(a)
 	}
 }

--- a/arena_gc_test.go
+++ b/arena_gc_test.go
@@ -1180,53 +1180,142 @@ func TestArenaGCSafety_StringValueBytes_HeapInput(t *testing.T) {
 	}
 }
 
-// TestArenaGCSafety_MixingHeapAndArenaValues_Demonstration documents the unsafe
-// pattern of storing a heap-allocated *Value into an arena-allocated container.
-//
-// Arena buffers are []byte allocations (noscan). The GC does not trace pointer
-// fields within arena memory. If a heap-allocated *Value is stored in an
-// arena-allocated []*kv or []*Value slice via Object.Set / SetArrayItem, and no
-// other GC-visible reference keeps that heap *Value alive, the GC may collect it.
-//
-// This test is skipped because it demonstrates undefined behavior that may or
-// may not manifest on a given run depending on GC timing and heap layout.
-func TestArenaGCSafety_MixingHeapAndArenaValues_Demonstration(t *testing.T) {
-	t.Skip("demonstrates unsafe heap/arena mixing — undefined behavior, not guaranteed to fail")
-
+// TestArenaGCSafety_DeepCopy_ObjectSet verifies that DeepCopy makes it safe to
+// store a heap-allocated *Value into an arena-allocated object via Object.Set.
+// Without DeepCopy the kv.v pointer lives in noscan arena memory, making the
+// heap Value invisible to the GC. With DeepCopy the stored value is fully
+// arena-allocated.
+func TestArenaGCSafety_DeepCopy_ObjectSet(t *testing.T) {
 	old := debug.SetGCPercent(1)
 	defer debug.SetGCPercent(old)
 
 	for i := 0; i < gcTestIterations; i++ {
 		a := arena.NewMonotonicArena()
 
-		// Arena-allocated container
 		obj := ObjectValue(a)
+		heapVal := StringValue(nil, heapString("safe", i))
 
-		// Heap-allocated value (nil arena)
-		heapVal := StringValue(nil, heapString("unsafe", i))
+		// DeepCopy copies heapVal into arena a before storing.
+		obj.Set(a, "key", DeepCopy(a, heapVal))
 
-		// Store heap *Value into arena-allocated kv slice.
-		// The kv.v pointer lives inside a []byte buffer (noscan).
-		// The GC cannot see this reference.
-		obj.Set(a, "key", heapVal)
-
-		// Drop the only GC-visible reference to heapVal.
+		// Drop the only external reference to heapVal.
 		heapVal = nil //nolint:ineffassign
-
-		// Force GC — heapVal may be collected since the only reference
-		// to it is inside arena memory (noscan).
 		forceGC()
 
-		// This read may return corrupted data or crash if the GC
-		// collected the heap Value.
 		got := obj.Get("key")
-		expected := heapString("unsafe", i)
+		expected := heapString("safe", i)
 		sb, _ := got.StringBytes()
 		if string(sb) != expected {
-			t.Fatalf("iteration %d: got %q, want %q (heap value may have been collected)", i, string(sb), expected)
+			t.Fatalf("iteration %d: got %q, want %q", i, string(sb), expected)
+		}
+		marshaled := string(obj.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
 		}
 		runtime.KeepAlive(a)
 	}
+}
+
+// TestArenaGCSafety_DeepCopy_SetArrayItem verifies that DeepCopy makes it safe
+// to store a heap-allocated *Value into an arena-allocated array via SetArrayItem.
+func TestArenaGCSafety_DeepCopy_SetArrayItem(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+
+		arr := ArrayValue(a)
+		heapVal := IntValue(nil, i)
+
+		arr.SetArrayItem(a, 0, DeepCopy(a, heapVal))
+
+		heapVal = nil //nolint:ineffassign
+		forceGC()
+
+		items, _ := arr.Array()
+		if len(items) != 1 {
+			t.Fatalf("iteration %d: want 1 item, got %d", i, len(items))
+		}
+		got := items[0].GetInt()
+		if got != i {
+			t.Fatalf("iteration %d: got %d, want %d", i, got, i)
+		}
+		marshaled := string(arr.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+// TestArenaGCSafety_DeepCopy_NestedObject verifies that DeepCopy recursively
+// copies nested objects and arrays onto the arena.
+func TestArenaGCSafety_DeepCopy_NestedObject(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+
+		// Build a nested heap value: {"name": "...", "scores": [1, 2, 3]}
+		heapObj := ObjectValue(nil)
+		heapObj.Set(nil, "name", StringValue(nil, heapString("nested", i)))
+		heapArr := ArrayValue(nil)
+		heapArr.SetArrayItem(nil, 0, IntValue(nil, i))
+		heapArr.SetArrayItem(nil, 1, IntValue(nil, i+1))
+		heapArr.SetArrayItem(nil, 2, IntValue(nil, i+2))
+		heapObj.Set(nil, "scores", heapArr)
+
+		arenaContainer := ObjectValue(a)
+		arenaContainer.Set(a, "data", DeepCopy(a, heapObj))
+
+		// Drop all heap references.
+		heapObj = nil //nolint:ineffassign
+		heapArr = nil //nolint:ineffassign
+		forceGC()
+
+		got := arenaContainer.Get("data", "name")
+		expected := heapString("nested", i)
+		sb, _ := got.StringBytes()
+		if string(sb) != expected {
+			t.Fatalf("iteration %d: name got %q, want %q", i, string(sb), expected)
+		}
+
+		scores := arenaContainer.GetArray("data", "scores")
+		if len(scores) != 3 {
+			t.Fatalf("iteration %d: want 3 scores, got %d", i, len(scores))
+		}
+		if scores[0].GetInt() != i || scores[1].GetInt() != i+1 || scores[2].GetInt() != i+2 {
+			t.Fatalf("iteration %d: unexpected scores", i)
+		}
+
+		marshaled := string(arenaContainer.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+		runtime.KeepAlive(a)
+	}
+}
+
+// TestArenaGCSafety_DeepCopy_NilArena verifies that DeepCopy(nil, v) is a
+// no-op and returns v unchanged.
+func TestArenaGCSafety_DeepCopy_NilArena(t *testing.T) {
+	v := StringValue(nil, "hello")
+	got := DeepCopy(nil, v)
+	if got != v {
+		t.Fatal("DeepCopy(nil, v) must return v unchanged")
+	}
+}
+
+// TestArenaGCSafety_DeepCopy_NilValue verifies that DeepCopy(a, nil) returns nil.
+func TestArenaGCSafety_DeepCopy_NilValue(t *testing.T) {
+	a := arena.NewMonotonicArena()
+	got := DeepCopy(a, nil)
+	if got != nil {
+		t.Fatal("DeepCopy(a, nil) must return nil")
+	}
+	runtime.KeepAlive(a)
 }
 
 func TestArenaGCSafety_UnescapeAllBranches(t *testing.T) {

--- a/arena_gc_test.go
+++ b/arena_gc_test.go
@@ -1613,7 +1613,6 @@ func TestArenaGCSafety_ArenaBufferGrowth(t *testing.T) {
 		if err != nil {
 			t.Fatalf("iteration %d: parse: %s", i, err)
 		}
-		buf = nil
 		forceGC()
 
 		arr := v.GetArray()
@@ -1832,7 +1831,6 @@ func TestArenaGCSafety_ManyObjectKeys(t *testing.T) {
 		if err != nil {
 			t.Fatalf("iteration %d: parse: %s", i, err)
 		}
-		buf = nil
 		forceGC()
 
 		o, _ := v.Object()

--- a/arena_gc_test.go
+++ b/arena_gc_test.go
@@ -1005,3 +1005,147 @@ func TestArenaGCSafety_ComplexWorkflow(t *testing.T) {
 		}
 	}
 }
+
+// heapJSON returns a heap-allocated JSON string with unique values per iteration.
+// The //go:noinline directive ensures the string is truly heap-allocated.
+//
+//go:noinline
+func heapJSON(i int) string {
+	return fmt.Sprintf(`{"name":"user_%d","age":%d,"score":3.14,"active":true,"tags":["tag_%d","arena"],"nested":{"key":"val_%d","count":%d}}`,
+		i, 20+i, i, i, i*10)
+}
+
+// TestArenaGCSafety_ParseWithArena_HeapInput tests that ParseWithArena is safe
+// when the input string is heap-allocated and goes out of scope before GC.
+// This catches the bug where parsed substrings (numbers, unescaped strings, keys)
+// reference the input's backing array which the GC can collect.
+func TestArenaGCSafety_ParseWithArena_HeapInput(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		// Use a heap-allocated JSON string (not a literal)
+		input := heapJSON(i)
+		v, err := p.ParseWithArena(a, input)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		// Drop reference to input so GC can collect it
+		input = ""
+		_ = input
+		forceGC()
+
+		// Verify string values (substrings of input)
+		name := v.GetStringBytes("name")
+		expected := fmt.Sprintf("user_%d", i)
+		if string(name) != expected {
+			t.Fatalf("iteration %d: name got %q, want %q", i, string(name), expected)
+		}
+
+		// Verify number values (substrings of input)
+		age := v.GetInt("age")
+		if age != 20+i {
+			t.Fatalf("iteration %d: age got %d, want %d", i, age, 20+i)
+		}
+		score := v.GetFloat64("score")
+		if score != 3.14 {
+			t.Fatalf("iteration %d: score got %f, want 3.14", i, score)
+		}
+
+		// Verify boolean
+		if !v.GetBool("active") {
+			t.Fatalf("iteration %d: active should be true", i)
+		}
+
+		// Verify array with string elements
+		tags := v.GetArray("tags")
+		if len(tags) != 2 {
+			t.Fatalf("iteration %d: expected 2 tags, got %d", i, len(tags))
+		}
+		tag0, _ := tags[0].StringBytes()
+		expectedTag := fmt.Sprintf("tag_%d", i)
+		if string(tag0) != expectedTag {
+			t.Fatalf("iteration %d: tag[0] got %q, want %q", i, string(tag0), expectedTag)
+		}
+
+		// Verify nested object (keys and values are substrings of input)
+		nested := v.Get("nested")
+		if nested == nil {
+			t.Fatalf("iteration %d: nested is nil", i)
+		}
+		nestedKey := nested.GetStringBytes("key")
+		expectedVal := fmt.Sprintf("val_%d", i)
+		if string(nestedKey) != expectedVal {
+			t.Fatalf("iteration %d: nested.key got %q, want %q", i, string(nestedKey), expectedVal)
+		}
+		nestedCount := nested.GetInt("count")
+		if nestedCount != i*10 {
+			t.Fatalf("iteration %d: nested.count got %d, want %d", i, nestedCount, i*10)
+		}
+
+		// Verify full marshal round-trip
+		marshaled := string(v.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+	}
+}
+
+// TestArenaGCSafety_ParseBytesWithArena_HeapInput tests that ParseBytesWithArena
+// is safe when the input byte slice is heap-allocated and not pre-copied to the arena.
+func TestArenaGCSafety_ParseBytesWithArena_HeapInput(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		var p Parser
+		// Use heap-allocated bytes directly — no manual arena copy
+		input := []byte(heapJSON(i))
+		v, err := p.ParseBytesWithArena(a, input)
+		if err != nil {
+			t.Fatalf("iteration %d: parse: %s", i, err)
+		}
+		// Drop reference to input
+		input = nil
+		forceGC()
+
+		name := v.GetStringBytes("name")
+		expected := fmt.Sprintf("user_%d", i)
+		if string(name) != expected {
+			t.Fatalf("iteration %d: name got %q, want %q", i, string(name), expected)
+		}
+		age := v.GetInt("age")
+		if age != 20+i {
+			t.Fatalf("iteration %d: age got %d, want %d", i, age, 20+i)
+		}
+		marshaled := string(v.MarshalTo(nil))
+		if len(marshaled) == 0 {
+			t.Fatalf("iteration %d: MarshalTo returned empty", i)
+		}
+	}
+}
+
+// TestArenaGCSafety_StringValueBytes_HeapInput tests that StringValueBytes
+// is safe when called with heap-allocated bytes without pre-copying to the arena.
+func TestArenaGCSafety_StringValueBytes_HeapInput(t *testing.T) {
+	old := debug.SetGCPercent(1)
+	defer debug.SetGCPercent(old)
+
+	for i := 0; i < gcTestIterations; i++ {
+		a := arena.NewMonotonicArena()
+		// Pass heap bytes directly — no manual arena copy
+		src := heapBytes("direct", i)
+		v := StringValueBytes(a, src)
+		// Drop reference to src
+		src = nil
+		forceGC()
+		got := v.String()
+		expected := `"` + fmt.Sprintf("direct_%d_padding_to_ensure_heap_allocation", i) + `"`
+		if got != expected {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, expected)
+		}
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -49,6 +49,40 @@ causing a use-after-free. The library prevents this by:
 When using heap mode (nil arena), all Values live on the heap where the GC can
 see them, so heap string references are safe.
 
+# Mixing Arena and Heap Values
+
+The noscan property extends beyond string data to all pointer fields within
+arena-allocated structs. Because arena buffers are raw []byte allocations, the
+GC does not trace pointer fields such as Value.a ([]*Value), Object.kvs ([]*kv),
+or kv.v (*Value) that live inside arena memory.
+
+This means storing a heap-allocated *Value into an arena-allocated container is
+unsafe if no other GC-visible reference to that heap Value exists. The GC may
+collect the heap Value since it cannot see the reference in arena memory,
+resulting in a use-after-free.
+
+Affected APIs (when the container is arena-allocated and the value is
+heap-allocated):
+
+  - [Object.Set] / [Value.Set]: the value argument is stored directly.
+  - [Value.SetArrayItem]: the value argument is stored directly.
+  - [AppendToArray] / [Value.AppendArrayItems]: elements are stored directly.
+  - [MergeValues] / [MergeValuesWithPath]: values from b may be stored in a.
+
+Safe patterns:
+
+  - All values from a single arena: always safe.
+  - All values on the heap (nil arena): always safe.
+  - Package-level singletons (valueTrue, valueFalse, valueNull, [NullValue]):
+    always safe because they are GC-visible global variables.
+
+Unsafe pattern:
+
+	arenaObj := ObjectValue(a)            // arena-allocated
+	heapVal := StringValue(nil, "hello")  // heap-allocated
+	arenaObj.Set(a, "key", heapVal)       // UNSAFE if heapVal has no other reference
+	heapVal = nil                         // GC may now collect the heap Value
+
 # Value Constructors
 
 Use [StringValue], [IntValue], [FloatValue], [NumberValue], [TrueValue],

--- a/doc.go
+++ b/doc.go
@@ -75,6 +75,8 @@ Safe patterns:
   - All values on the heap (nil arena): always safe.
   - Package-level singletons (valueTrue, valueFalse, valueNull, [NullValue]):
     always safe because they are GC-visible global variables.
+  - Using [DeepCopy] to copy a heap value onto the arena before storing it:
+    always safe because the copy lives entirely in arena memory.
 
 Unsafe pattern:
 
@@ -82,6 +84,13 @@ Unsafe pattern:
 	heapVal := StringValue(nil, "hello")  // heap-allocated
 	arenaObj.Set(a, "key", heapVal)       // UNSAFE if heapVal has no other reference
 	heapVal = nil                         // GC may now collect the heap Value
+
+Safe pattern using DeepCopy:
+
+	arenaObj := ObjectValue(a)
+	heapVal := StringValue(nil, "hello")  // heap-allocated
+	arenaObj.Set(a, "key", DeepCopy(a, heapVal))  // safe: copy lives in a
+	heapVal = nil                                  // GC collects original, copy is in a
 
 # Value Constructors
 

--- a/doc.go
+++ b/doc.go
@@ -1,8 +1,65 @@
 /*
-Package astjson provides fast JSON parsing.
+Package astjson provides fast JSON parsing with optional arena allocation.
 
-Arbitrary JSON may be parsed by fastjson without the need for creating structs
-or for generating go code. Just parse JSON and get the required fields with
-Get* functions.
+Arbitrary JSON may be parsed without creating structs or generating Go code.
+Just parse JSON and get the required fields with Get* functions.
+
+# Heap Mode vs Arena Mode
+
+The library operates in two memory modes depending on whether an [arena.Arena]
+is provided:
+
+Heap mode (nil arena): All Value structs and their backing data are allocated
+on the Go heap. The garbage collector tracks all references normally. Use
+[Parse], [ParseBytes], or [Parser.Parse] / [Parser.ParseBytes] for this mode.
+Parsed values remain valid until the next call to any Parse method on the same
+Parser, or indefinitely when using the package-level convenience functions.
+
+Arena mode (non-nil arena): All Value structs, string backing bytes, and slice
+backing arrays are allocated on the arena. The Go GC does not scan arena memory,
+so the library copies all input data onto the arena before parsing. This means
+the caller can drop references to the input string/bytes immediately after
+parsing. Parsed values remain valid for the lifetime of the arena. Use
+[ParseWithArena], [ParseBytesWithArena], or [Parser.ParseWithArena] /
+[Parser.ParseBytesWithArena] for this mode.
+
+Arena mode is useful for high-throughput parsing where GC pressure from millions
+of small Value allocations would degrade performance. Instead of creating heap
+garbage, all allocations go into a contiguous arena buffer that can be reset and
+reused.
+
+# GC Safety Invariant
+
+When using arena mode, the following invariant is maintained automatically:
+
+Arena-allocated Values never reference heap-allocated string data.
+
+This is critical because the GC does not scan arena memory for pointers. If an
+arena-allocated Value.s field pointed to a heap string's backing array, the GC
+could collect that string (since it cannot see the reference in arena memory),
+causing a use-after-free. The library prevents this by:
+
+  - Copying the entire input string/bytes onto the arena before parsing, so all
+    parsed substrings (number literals, string values, object keys) point into
+    arena memory.
+  - Copying string arguments onto the arena in value constructors like
+    [StringValue], [IntValue], etc.
+  - Copying object keys onto the arena in [Object.Set].
+
+When using heap mode (nil arena), all Values live on the heap where the GC can
+see them, so heap string references are safe.
+
+# Value Constructors
+
+Use [StringValue], [IntValue], [FloatValue], [NumberValue], [TrueValue],
+[FalseValue], [ObjectValue], and [ArrayValue] to create new values. These
+accept an [arena.Arena] parameter: pass nil for heap allocation or a non-nil
+arena for arena allocation. All string data is automatically copied onto the
+arena when a non-nil arena is provided.
+
+# Concurrency
+
+[Parser], [Value], [Object], and [Scanner] cannot be used from concurrent
+goroutines. Use per-goroutine instances.
 */
 package astjson

--- a/fastfloat/parse.go
+++ b/fastfloat/parse.go
@@ -288,9 +288,6 @@ func ParseBestEffort(s string) float64 {
 			}
 			break
 		}
-		if i < k {
-			return 0
-		}
 		// Convert the entire mantissa to a float at once to avoid rounding errors.
 		f = float64(d) / float64pow10[i-k]
 		if i >= uint(len(s)) {
@@ -443,9 +440,6 @@ func Parse(s string) (float64, error) {
 				continue
 			}
 			break
-		}
-		if i < k {
-			return 0, fmt.Errorf("cannot find mantissa in %q", s)
 		}
 		// Convert the entire mantissa to a float at once to avoid rounding errors.
 		f = float64(d) / float64pow10[i-k]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wundergraph/astjson
 
-go 1.26
+go 1.25
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wundergraph/astjson
 
-go 1.25
+go 1.26
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/handy.go
+++ b/handy.go
@@ -127,6 +127,15 @@ func Parse(s string) (*Value, error) {
 	return p.Parse(s)
 }
 
+// ParseWithArena parses json string s, allocating all values on the arena.
+//
+// The input string is copied onto the arena before parsing, so the caller may
+// drop references to s immediately after this call returns. All parsed values
+// live entirely in arena memory and are valid for the arena's lifetime.
+//
+// When a is nil, behaves identically to Parse (heap allocation).
+//
+// The function is slower than Parser.ParseWithArena for re-used Parser.
 func ParseWithArena(a arena.Arena, s string) (*Value, error) {
 	var p Parser
 	return p.ParseWithArena(a, s)
@@ -152,6 +161,17 @@ func ParseBytes(b []byte) (*Value, error) {
 	return p.ParseBytes(b)
 }
 
+// ParseBytesWithArena parses b containing json, allocating all values on the
+// arena.
+//
+// The input bytes are copied onto the arena before parsing, so the caller may
+// reuse or discard b immediately after this call returns. All parsed values
+// live entirely in arena memory and are valid for the arena's lifetime.
+//
+// When a is nil, behaves identically to ParseBytes (heap allocation). In that
+// case the caller must not modify b while the returned Value is in use.
+//
+// The function is slower than Parser.ParseBytesWithArena for re-used Parser.
 func ParseBytesWithArena(a arena.Arena, b []byte) (*Value, error) {
 	var p Parser
 	return p.ParseBytesWithArena(a, b)

--- a/handy_test.go
+++ b/handy_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/wundergraph/go-arena"
 )
 
 func TestGetStringConcurrent(t *testing.T) {
@@ -274,6 +276,28 @@ func TestMustParse(t *testing.T) {
 
 	if !causesPanic(func() { v = MustParseBytes([]byte(`[`)) }) {
 		t.Fatalf("expected MustParse to panic")
+	}
+}
+
+func TestParseWithArenaHandy(t *testing.T) {
+	a := arena.NewMonotonicArena()
+	v, err := ParseWithArena(a, `{"foo":"bar"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if v.GetStringBytes("foo") == nil {
+		t.Fatalf("expected non-nil value")
+	}
+}
+
+func TestParseBytesWithArenaHandy(t *testing.T) {
+	a := arena.NewMonotonicArena()
+	v, err := ParseBytesWithArena(a, []byte(`{"foo":"bar"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if v.GetStringBytes("foo") == nil {
+		t.Fatalf("expected non-nil value")
 	}
 }
 

--- a/mergevalues.go
+++ b/mergevalues.go
@@ -118,12 +118,10 @@ func MergeValuesWithPath(ar arena.Arena, a, b *Value, path ...string) (v *Value,
 	if len(path) == 0 {
 		return MergeValues(ar, a, b)
 	}
-	root := &Value{
-		t: TypeObject,
-	}
+	root := ObjectValue(ar)
 	current := root
 	for i := 0; i < len(path)-1; i++ {
-		current.Set(ar, path[i], &Value{t: TypeObject})
+		current.Set(ar, path[i], ObjectValue(ar))
 		current = current.Get(path[i])
 	}
 	current.Set(ar, path[len(path)-1], b)

--- a/mergevalues.go
+++ b/mergevalues.go
@@ -91,9 +91,6 @@ func MergeValues(ar arena.Arena, a, b *Value) (v *Value, changed bool, err error
 		}
 		return a, false, nil
 	case TypeNull:
-		if b.Type() != TypeNull {
-			return b, true, nil
-		}
 		return a, false, nil
 	case TypeNumber:
 		af, _ := a.Float64()

--- a/mergevalues.go
+++ b/mergevalues.go
@@ -8,11 +8,25 @@ import (
 )
 
 var (
-	ErrMergeDifferentTypes        = errors.New("cannot merge different types")
+	// ErrMergeDifferentTypes is returned when merging two values of incompatible types.
+	ErrMergeDifferentTypes = errors.New("cannot merge different types")
+	// ErrMergeDifferingArrayLengths is returned when merging arrays of different lengths.
 	ErrMergeDifferingArrayLengths = errors.New("cannot merge arrays of differing lengths")
-	ErrMergeUnknownType           = errors.New("cannot merge unknown type")
+	// ErrMergeUnknownType is returned when merging a value with an unrecognized type.
+	ErrMergeUnknownType = errors.New("cannot merge unknown type")
 )
 
+// MergeValues recursively merges b into a and returns the result. For objects,
+// keys from b are added to or replace keys in a. For arrays, elements are
+// merged pairwise (arrays must have equal length). For scalars, b replaces a
+// when the values differ.
+//
+// The arena ar is used for any new allocations during the merge (new object
+// entries, key copies). Both a and b should have been allocated using the same
+// arena (or both on the heap) to avoid mixing memory lifetimes.
+//
+// Returns the merged value, whether a was changed, and any error.
+// If a is nil, returns (b, true, nil). If b is nil, returns (a, false, nil).
 func MergeValues(ar arena.Arena, a, b *Value) (v *Value, changed bool, err error) {
 	if a == nil {
 		return b, true, nil
@@ -111,6 +125,13 @@ func MergeValues(ar arena.Arena, a, b *Value) (v *Value, changed bool, err error
 	}
 }
 
+// MergeValuesWithPath wraps b in a nested object structure at the given path,
+// then merges the result into a using [MergeValues]. For example, with
+// path ["foo", "bar"], b is wrapped as {"foo": {"bar": b}} before merging.
+//
+// If path is empty, behaves identically to [MergeValues].
+//
+// The arena ar is used for allocating the wrapper objects and during the merge.
 func MergeValuesWithPath(ar arena.Arena, a, b *Value, path ...string) (v *Value, changed bool, err error) {
 	if len(path) == 0 {
 		return MergeValues(ar, a, b)

--- a/mergevalues_test.go
+++ b/mergevalues_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/go-arena"
 )
 
 func TestMergeValues(t *testing.T) {
@@ -304,5 +305,29 @@ func TestMergeValues(t *testing.T) {
 		right := MustParse(`{"a":{"b":"c"}}`)
 		_, _, err := MergeValues(nil, left, right)
 		require.Error(t, err)
+	})
+	t.Run("unknown type", func(t *testing.T) {
+		t.Parallel()
+		a := &Value{t: Type(99)}
+		b := &Value{t: Type(99)}
+		_, _, err := MergeValues(nil, a, b)
+		require.Equal(t, ErrMergeUnknownType, err)
+	})
+	t.Run("object with unescaped key", func(t *testing.T) {
+		t.Parallel()
+		ar := arena.NewMonotonicArena()
+		left := MustParse(`{"foo":1}`)
+
+		right := &Value{t: TypeObject}
+		entry := &kv{
+			k:            `bar`,
+			v:            MustParse(`2`),
+			keyUnescaped: false,
+		}
+		right.o.kvs = append(right.o.kvs, entry)
+
+		merged, _, err := MergeValues(ar, left, right)
+		require.NoError(t, err)
+		require.NotNil(t, merged.Get("bar"))
 	})
 }

--- a/parser.go
+++ b/parser.go
@@ -48,6 +48,9 @@ func (p *Parser) Parse(s string) (*Value, error) {
 }
 
 func (p *Parser) ParseWithArena(a arena.Arena, s string) (*Value, error) {
+	if a != nil {
+		s = arenaString(a, s)
+	}
 	return p.parse(a, s)
 }
 
@@ -61,7 +64,12 @@ func (p *Parser) ParseBytes(b []byte) (*Value, error) {
 }
 
 func (p *Parser) ParseBytesWithArena(a arena.Arena, b []byte) (*Value, error) {
-	return p.parse(a, b2s(b))
+	if a != nil {
+		ab := arena.AllocateSlice[byte](a, len(b), len(b))
+		copy(ab, b)
+		return p.parse(a, b2s(ab))
+	}
+	return p.parse(nil, b2s(b))
 }
 
 func (p *Parser) parse(a arena.Arena, s string) (*Value, error) {
@@ -596,25 +604,12 @@ func (o *Object) Len() int {
 //
 // The returned value is valid until Parse is called on the Parser returned o.
 func (o *Object) Get(key string) *Value {
-
 	if o == nil {
 		return nil
 	}
-
-	// Fast path - direct comparison works because keys are pre-unescaped during parsing
-	if strings.IndexByte(key, '\\') < 0 {
-		for _, kv := range o.kvs {
-			if kv.k == key {
-				return kv.v
-			}
-		}
-	}
-
-	// Slow path - unescape keys as needed and search
+	// Keys are always pre-unescaped during parsing and Object.Set,
+	// so direct comparison is sufficient.
 	for _, kv := range o.kvs {
-		if !kv.keyUnescaped {
-			o.unescapeKey(nil, kv)
-		}
 		if kv.k == key {
 			return kv.v
 		}
@@ -630,11 +625,8 @@ func (o *Object) Visit(f func(key []byte, v *Value)) {
 	if o == nil {
 		return
 	}
-
+	// Keys are always pre-unescaped during parsing and Object.Set.
 	for _, kv := range o.kvs {
-		if !kv.keyUnescaped {
-			o.unescapeKey(nil, kv)
-		}
 		f(s2b(kv.k), kv.v)
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -584,11 +584,9 @@ func (o *Object) getKV(a arena.Arena) *kv {
 	return o.kvs[len(o.kvs)-1]
 }
 
-// unescapeKey unescapes a specific key if it hasn't been unescaped yet.
+// unescapeKey unescapes a specific key.
+// Callers must check kv.keyUnescaped before calling.
 func (o *Object) unescapeKey(a arena.Arena, kv *kv) {
-	if kv.keyUnescaped {
-		return
-	}
 	kv.k = unescapeStringBestEffort(a, kv.k)
 	kv.keyUnescaped = true
 }
@@ -840,11 +838,7 @@ func (v *Value) GetInt(keys ...string) int {
 		return 0
 	}
 	n := fastfloat.ParseInt64BestEffort(v.s)
-	nn := int(n)
-	if int64(nn) != n {
-		return 0
-	}
-	return nn
+	return int(n)
 }
 
 // GetUint returns uint value by the given keys path.
@@ -858,11 +852,7 @@ func (v *Value) GetUint(keys ...string) uint {
 		return 0
 	}
 	n := fastfloat.ParseUint64BestEffort(v.s)
-	nn := uint(n)
-	if uint64(nn) != n {
-		return 0
-	}
-	return nn
+	return uint(n)
 }
 
 // GetInt64 returns int64 value by the given keys path.
@@ -976,11 +966,7 @@ func (v *Value) Int() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	nn := int(n)
-	if int64(nn) != n {
-		return 0, fmt.Errorf("number %q doesn't fit int", v.s)
-	}
-	return nn, nil
+	return int(n), nil
 }
 
 // Uint returns the underlying JSON uint for the v.
@@ -994,11 +980,7 @@ func (v *Value) Uint() (uint, error) {
 	if err != nil {
 		return 0, err
 	}
-	nn := uint(n)
-	if uint64(nn) != n {
-		return 0, fmt.Errorf("number %q doesn't fit uint", v.s)
-	}
-	return nn, nil
+	return uint(n), nil
 }
 
 // Int64 returns the underlying JSON int64 for the v.

--- a/parser.go
+++ b/parser.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/wundergraph/astjson/fastfloat"
 	"github.com/wundergraph/go-arena"
@@ -453,7 +454,9 @@ func unescapeStringBestEffort(a arena.Arena, s string) string {
 			}
 			s = s[4:]
 			if !utf16.IsSurrogate(rune(x)) {
-				b = arena.SliceAppend(a, b, []byte(string(rune(x)))...)
+				var buf [utf8.UTFMax]byte
+				n := utf8.EncodeRune(buf[:], rune(x))
+				b = arena.SliceAppend(a, b, buf[:n]...)
 				break
 			}
 
@@ -471,7 +474,9 @@ func unescapeStringBestEffort(a arena.Arena, s string) string {
 				break
 			}
 			r := utf16.DecodeRune(rune(x), rune(x1))
-			b = arena.SliceAppend(a, b, []byte(string(r))...)
+			var buf [utf8.UTFMax]byte
+			rn := utf8.EncodeRune(buf[:], r)
+			b = arena.SliceAppend(a, b, buf[:rn]...)
 			s = s[6:]
 		default:
 			// Unknown escape sequence. Just store it unchanged.

--- a/parser.go
+++ b/parser.go
@@ -267,6 +267,8 @@ func parseObject(a arena.Arena, s string, depth int) (*Value, string, error) {
 		if err != nil {
 			return nil, s, fmt.Errorf("cannot parse object key: %s", err)
 		}
+		kv.k = unescapeStringBestEffort(a, kv.k)
+		kv.keyUnescaped = true
 		s = skipWS(s)
 		if len(s) == 0 || s[0] != ':' {
 			return nil, s, fmt.Errorf("missing ':' after object key")
@@ -599,10 +601,10 @@ func (o *Object) Get(key string) *Value {
 		return nil
 	}
 
-	// Fast path - try searching for the key without unescaping if the key doesn't contain escapes
+	// Fast path - direct comparison works because keys are pre-unescaped during parsing
 	if strings.IndexByte(key, '\\') < 0 {
 		for _, kv := range o.kvs {
-			if !kv.keyUnescaped && kv.k == key {
+			if kv.k == key {
 				return kv.v
 			}
 		}

--- a/parser.go
+++ b/parser.go
@@ -10,10 +10,12 @@ import (
 	"github.com/wundergraph/go-arena"
 )
 
+// ParseError wraps a JSON parsing error.
 type ParseError struct {
 	Err error
 }
 
+// Error returns the error message. Returns an empty string if p is nil.
 func (p *ParseError) Error() string {
 	if p == nil {
 		return ""
@@ -21,6 +23,7 @@ func (p *ParseError) Error() string {
 	return p.Err.Error()
 }
 
+// NewParseError wraps err in a ParseError. Returns nil if err is nil.
 func NewParseError(err error) *ParseError {
 	if err == nil {
 		return nil
@@ -32,6 +35,12 @@ func NewParseError(err error) *ParseError {
 // Parser parses JSON.
 //
 // Parser may be re-used for subsequent parsing.
+//
+// Parser supports two allocation modes: heap mode (Parse, ParseBytes) where
+// all values are heap-allocated and GC-managed, and arena mode
+// (ParseWithArena, ParseBytesWithArena) where all values and their backing
+// data are allocated on a caller-provided arena. See the package
+// documentation for details on GC safety.
 //
 // Parser cannot be used from concurrent goroutines.
 // Use per-goroutine parsers or ParserPool instead.
@@ -47,6 +56,16 @@ func (p *Parser) Parse(s string) (*Value, error) {
 	return p.parse(nil, s)
 }
 
+// ParseWithArena parses s containing JSON, allocating all values on the arena.
+//
+// The input string s is copied onto the arena before parsing, so the caller
+// may drop references to s immediately after this call returns. All parsed
+// Values, their string data, object keys, and array backing slices live
+// entirely in arena memory, making the result independent of the GC.
+//
+// The returned value is valid for the lifetime of the arena.
+//
+// When a is nil, behaves identically to Parse (heap allocation).
 func (p *Parser) ParseWithArena(a arena.Arena, s string) (*Value, error) {
 	if a != nil {
 		s = arenaString(a, s)
@@ -63,6 +82,19 @@ func (p *Parser) ParseBytes(b []byte) (*Value, error) {
 	return p.parse(nil, b2s(b))
 }
 
+// ParseBytesWithArena parses b containing JSON, allocating all values on the
+// arena.
+//
+// The input bytes b are copied onto the arena before parsing, so the caller
+// may reuse or discard b immediately after this call returns. All parsed
+// Values, their string data, object keys, and array backing slices live
+// entirely in arena memory, making the result independent of the GC.
+//
+// The returned value is valid for the lifetime of the arena.
+//
+// When a is nil, behaves identically to ParseBytes (heap allocation). In that
+// case the caller must not modify b while the returned Value is in use, as it
+// may reference b's underlying memory via zero-copy conversion.
 func (p *Parser) ParseBytesWithArena(a arena.Arena, b []byte) (*Value, error) {
 	if a != nil {
 		ab := arena.AllocateSlice[byte](a, len(b), len(b))

--- a/parser_test.go
+++ b/parser_test.go
@@ -2102,3 +2102,37 @@ func TestGetIntGetUintOverflow(t *testing.T) {
 		}
 	})
 }
+
+func TestParseBytesWithArenaNilArena(t *testing.T) {
+	var p Parser
+	v, err := p.ParseBytesWithArena(nil, []byte(`[1,2,3]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if v.Type() != TypeArray {
+		t.Fatalf("expected array type, got %v", v.Type())
+	}
+}
+
+func TestObjectMarshalToRawKey(t *testing.T) {
+	// Construct an object with a key that hasn't been unescaped (keyUnescaped=false).
+	// In this case MarshalTo should emit the raw key wrapped in quotes without escaping.
+	o := &Object{}
+	entry := &kv{
+		k:             `already\"escaped`,
+		v:             valueNull,
+		keyUnescaped:  false,
+	}
+	o.kvs = append(o.kvs, entry)
+
+	result := string(o.MarshalTo(nil))
+	expected := `{"already\"escaped":null}`
+	if result != expected {
+		t.Fatalf("got %q, want %q", result, expected)
+	}
+}
+
+func TestUnescapeStringBestEffortInvalidSurrogatePairHex(t *testing.T) {
+	// High surrogate \ud83e followed by \u with invalid hex digits
+	testUnescapeStringBestEffort(t, `\ud83e\uzzzz`, `\ud83e\uzzzz`)
+}

--- a/update.go
+++ b/update.go
@@ -44,6 +44,12 @@ func (v *Value) Del(key string) {
 // Set sets (key, value) entry in the o.
 //
 // The value must be unchanged during o lifetime.
+//
+// GC safety: when o is arena-allocated (a is non-nil), value must also be
+// arena-allocated from the same arena, or be a package-level singleton.
+// Storing a heap-allocated *Value in arena memory is unsafe because the GC
+// does not trace pointers within arena buffers. See the package documentation
+// section "Mixing Arena and Heap Values" for details.
 func (o *Object) Set(a arena.Arena, key string, value *Value) {
 	if o == nil {
 		return
@@ -93,6 +99,10 @@ func (v *Value) Set(a arena.Arena, key string, value *Value) {
 // SetArrayItem sets the value in the array v at idx position.
 //
 // The value must be unchanged during v lifetime.
+//
+// GC safety: when v is arena-allocated (a is non-nil), value must also be
+// arena-allocated from the same arena, or be a package-level singleton.
+// See the package documentation section "Mixing Arena and Heap Values".
 func (v *Value) SetArrayItem(a arena.Arena, idx int, value *Value) {
 	if v == nil || v.t != TypeArray {
 		return

--- a/update.go
+++ b/update.go
@@ -16,6 +16,7 @@ func (o *Object) Del(key string) {
 	for i, kv := range o.kvs {
 		if kv.k == key {
 			o.kvs = append(o.kvs[:i], o.kvs[i+1:]...)
+			o.kvs[:len(o.kvs)+1][len(o.kvs)] = nil // clear hidden slot for GC
 			return
 		}
 	}
@@ -36,6 +37,7 @@ func (v *Value) Del(key string) {
 			return
 		}
 		v.a = append(v.a[:n], v.a[n+1:]...)
+		v.a[:len(v.a)+1][len(v.a)] = nil // clear hidden slot for GC
 	}
 }
 

--- a/update.go
+++ b/update.go
@@ -13,9 +13,9 @@ func (o *Object) Del(key string) {
 		return
 	}
 	if strings.IndexByte(key, '\\') < 0 {
-		// Fast path - try searching for the key without unescaping
+		// Fast path - direct comparison works because keys are pre-unescaped during parsing
 		for i, kv := range o.kvs {
-			if !kv.keyUnescaped && kv.k == key {
+			if kv.k == key {
 				o.kvs = append(o.kvs[:i], o.kvs[i+1:]...)
 				return
 			}
@@ -76,7 +76,7 @@ func (o *Object) Set(a arena.Arena, key string, value *Value) {
 
 	// Add new entry.
 	kv := o.getKV(a)
-	kv.k = key
+	kv.k = arenaString(a, key)
 	kv.v = value
 	kv.keyUnescaped = true // New keys are already unescaped since they come from user input
 }

--- a/update.go
+++ b/update.go
@@ -48,8 +48,9 @@ func (v *Value) Del(key string) {
 // GC safety: when o is arena-allocated (a is non-nil), value must also be
 // arena-allocated from the same arena, or be a package-level singleton.
 // Storing a heap-allocated *Value in arena memory is unsafe because the GC
-// does not trace pointers within arena buffers. See the package documentation
-// section "Mixing Arena and Heap Values" for details.
+// does not trace pointers within arena buffers. Use [DeepCopy] to copy a
+// heap-allocated value onto the arena before passing it here. See the package
+// documentation section "Mixing Arena and Heap Values" for details.
 func (o *Object) Set(a arena.Arena, key string, value *Value) {
 	if o == nil {
 		return
@@ -102,7 +103,8 @@ func (v *Value) Set(a arena.Arena, key string, value *Value) {
 //
 // GC safety: when v is arena-allocated (a is non-nil), value must also be
 // arena-allocated from the same arena, or be a package-level singleton.
-// See the package documentation section "Mixing Arena and Heap Values".
+// Use [DeepCopy] to copy a heap-allocated value onto the arena before passing
+// it here. See the package documentation section "Mixing Arena and Heap Values".
 func (v *Value) SetArrayItem(a arena.Arena, idx int, value *Value) {
 	if v == nil || v.t != TypeArray {
 		return

--- a/update.go
+++ b/update.go
@@ -2,7 +2,6 @@ package astjson
 
 import (
 	"strconv"
-	"strings"
 
 	"github.com/wundergraph/go-arena"
 )
@@ -12,21 +11,9 @@ func (o *Object) Del(key string) {
 	if o == nil {
 		return
 	}
-	if strings.IndexByte(key, '\\') < 0 {
-		// Fast path - direct comparison works because keys are pre-unescaped during parsing
-		for i, kv := range o.kvs {
-			if kv.k == key {
-				o.kvs = append(o.kvs[:i], o.kvs[i+1:]...)
-				return
-			}
-		}
-	}
-
-	// Slow path - unescape keys as needed and search
+	// Keys are always pre-unescaped during parsing and Object.Set,
+	// so direct comparison is sufficient.
 	for i, kv := range o.kvs {
-		if !kv.keyUnescaped {
-			o.unescapeKey(nil, kv)
-		}
 		if kv.k == key {
 			o.kvs = append(o.kvs[:i], o.kvs[i+1:]...)
 			return

--- a/update_test.go
+++ b/update_test.go
@@ -606,3 +606,25 @@ func TestObjectDelWithNilArena(t *testing.T) {
 		t.Fatalf("expected key 'x' to still exist")
 	}
 }
+
+func TestObjectSetWithUnescapedKey(t *testing.T) {
+	// Construct an object with a key that hasn't been unescaped yet.
+	// When Set iterates over existing keys, it should call unescapeKey.
+	a := arena.NewMonotonicArena()
+	o := &Object{}
+	entry := &kv{
+		k:            `hello`,
+		v:            valueNull,
+		keyUnescaped: false,
+	}
+	o.kvs = append(o.kvs, entry)
+
+	o.Set(a, "other", MustParse(`1`))
+
+	if !o.kvs[0].keyUnescaped {
+		t.Fatalf("expected key to be unescaped after Set")
+	}
+	if o.Len() != 2 {
+		t.Fatalf("expected 2 keys, got %d", o.Len())
+	}
+}

--- a/update_test.go
+++ b/update_test.go
@@ -110,7 +110,7 @@ func TestValueDelSet(t *testing.T) {
 func TestValue_AppendArrayItems(t *testing.T) {
 	left := MustParse(`[1,2,3]`)
 	right := MustParse(`[4,5,6]`)
-	left.AppendArrayItems(right)
+	left.AppendArrayItems(nil, right)
 	if len(left.GetArray()) != 6 {
 		t.Fatalf("unexpected length; got %d; want %d", len(left.GetArray()), 6)
 	}

--- a/util.go
+++ b/util.go
@@ -2,6 +2,8 @@ package astjson
 
 import (
 	"unsafe"
+
+	"github.com/wundergraph/go-arena"
 )
 
 func b2s(b []byte) string {
@@ -10,6 +12,17 @@ func b2s(b []byte) string {
 
 func s2b(s string) (b []byte) {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
+}
+
+// arenaString copies the string bytes onto the arena when a is non-nil.
+// When a is nil, returns s unchanged (heap string in heap struct is GC-safe).
+func arenaString(a arena.Arena, s string) string {
+	if a == nil {
+		return s
+	}
+	b := arena.AllocateSlice[byte](a, len(s), len(s))
+	copy(b, s)
+	return b2s(b)
 }
 
 const maxStartEndStringLen = 80
@@ -27,29 +40,31 @@ var (
 	NullValue = MustParse(`null`)
 )
 
-func AppendToArray(array, value *Value) {
+func AppendToArray(a arena.Arena, array, value *Value) {
 	if array.Type() != TypeArray {
 		return
 	}
 	items, _ := array.Array()
-	array.SetArrayItem(nil, len(items), value)
+	array.SetArrayItem(a, len(items), value)
 }
 
-func SetValue(v *Value, value *Value, path ...string) {
+func SetValue(a arena.Arena, v *Value, value *Value, path ...string) {
 	for i := 0; i < len(path)-1; i++ {
 		parent := v
 		v = v.Get(path[i])
 		if v == nil {
-			child := MustParse(`{}`)
-			parent.Set(nil, path[i], child)
-			v = child
+			child := ObjectValue(a)
+			parent.Set(a, path[i], child)
+			v = parent.Get(path[i])
 		}
 	}
-	v.Set(nil, path[len(path)-1], value)
+	v.Set(a, path[len(path)-1], value)
 }
 
-func SetNull(v *Value, path ...string) {
-	SetValue(v, MustParse(`null`), path...)
+func SetNull(a arena.Arena, v *Value, path ...string) {
+	null := arena.Allocate[Value](a)
+	null.t = TypeNull
+	SetValue(a, v, null, path...)
 }
 
 func ValueIsNonNull(v *Value) bool {
@@ -62,11 +77,13 @@ func ValueIsNonNull(v *Value) bool {
 	return true
 }
 
-func (v *Value) AppendArrayItems(right *Value) {
+func (v *Value) AppendArrayItems(a arena.Arena, right *Value) {
 	if v.t != TypeArray || right.t != TypeArray {
 		return
 	}
-	v.a = append(v.a, right.a...)
+	for _, item := range right.a {
+		v.a = arena.SliceAppend(a, v.a, item)
+	}
 }
 
 func ValueIsNull(v *Value) bool {

--- a/util.go
+++ b/util.go
@@ -48,6 +48,7 @@ var (
 //
 // GC safety: when array is arena-allocated (a is non-nil), value must also be
 // arena-allocated from the same arena, or be a package-level singleton.
+// Use [DeepCopy] on value before calling if value is heap-allocated.
 // See the package documentation section "Mixing Arena and Heap Values".
 func AppendToArray(a arena.Arena, array, value *Value) {
 	if array.Type() != TypeArray {
@@ -96,13 +97,67 @@ func ValueIsNonNull(v *Value) bool {
 	return true
 }
 
+// DeepCopy returns a deep copy of v allocated entirely on arena a.
+// All string data, slice backing arrays, child Values, and object keys
+// are arena-allocated, making the result self-contained within a.
+//
+// Use DeepCopy when inserting a heap-parsed *Value into an arena-allocated
+// container (via [Object.Set], [Value.SetArrayItem], [AppendArrayItems], etc.)
+// to prevent the GC from collecting the value while the arena container still
+// references it. Example:
+//
+//	heapVal, _ := Parse(`"hello"`)                       // heap-allocated
+//	arenaObj.Set(a, "key", DeepCopy(a, heapVal))         // safe: copy lives in a
+//
+// When a is nil (heap mode), DeepCopy returns v unchanged. In heap mode the GC
+// traces all references normally, so no copy is needed.
+func DeepCopy(a arena.Arena, v *Value) *Value {
+	if v == nil || a == nil {
+		return v
+	}
+	cp := arena.Allocate[Value](a)
+	cp.t = v.t
+	switch v.t {
+	case TypeString, TypeNumber:
+		cp.s = arenaString(a, v.s)
+	case TypeObject:
+		cp.o = deepCopyObject(a, &v.o)
+	case TypeArray:
+		if len(v.a) > 0 {
+			cp.a = arena.AllocateSlice[*Value](a, len(v.a), len(v.a))
+			for i, item := range v.a {
+				cp.a[i] = DeepCopy(a, item)
+			}
+		}
+	// TypeTrue, TypeFalse, TypeNull: only t is needed, already set above.
+	}
+	return cp
+}
+
+func deepCopyObject(a arena.Arena, o *Object) Object {
+	var result Object
+	if len(o.kvs) == 0 {
+		return result
+	}
+	result.kvs = arena.AllocateSlice[*kv](a, len(o.kvs), len(o.kvs))
+	for i, entry := range o.kvs {
+		newKv := arena.Allocate[kv](a)
+		newKv.k = arenaString(a, entry.k)
+		newKv.keyUnescaped = true
+		newKv.v = DeepCopy(a, entry.v)
+		result.kvs[i] = newKv
+	}
+	return result
+}
+
 // AppendArrayItems appends all elements from right into v. Both v and right
 // must be TypeArray; does nothing otherwise. The arena a is used to grow v's
 // backing slice.
 //
 // GC safety: when v is arena-allocated (a is non-nil), right and its elements
-// must also be arena-allocated from the same arena. See the package
-// documentation section "Mixing Arena and Heap Values".
+// must also be arena-allocated from the same arena. Use [DeepCopy] on right
+// before calling if right is heap-allocated. See the package documentation
+// section "Mixing Arena and Heap Values".
 func (v *Value) AppendArrayItems(a arena.Arena, right *Value) {
 	if v.t != TypeArray || right.t != TypeArray {
 		return

--- a/util.go
+++ b/util.go
@@ -45,6 +45,10 @@ var (
 
 // AppendToArray appends value to the end of array. Does nothing if array is
 // not of TypeArray. The arena a is used to grow the array's backing slice.
+//
+// GC safety: when array is arena-allocated (a is non-nil), value must also be
+// arena-allocated from the same arena, or be a package-level singleton.
+// See the package documentation section "Mixing Arena and Heap Values".
 func AppendToArray(a arena.Arena, array, value *Value) {
 	if array.Type() != TypeArray {
 		return
@@ -58,7 +62,8 @@ func AppendToArray(a arena.Arena, array, value *Value) {
 // must have at least one element.
 //
 // Object keys created along the path are copied onto the arena when a is
-// non-nil, ensuring GC safety.
+// non-nil, ensuring GC safety. The same arena/heap mixing rules as
+// [Object.Set] apply to the value argument.
 func SetValue(a arena.Arena, v *Value, value *Value, path ...string) {
 	for i := 0; i < len(path)-1; i++ {
 		parent := v
@@ -94,6 +99,10 @@ func ValueIsNonNull(v *Value) bool {
 // AppendArrayItems appends all elements from right into v. Both v and right
 // must be TypeArray; does nothing otherwise. The arena a is used to grow v's
 // backing slice.
+//
+// GC safety: when v is arena-allocated (a is non-nil), right and its elements
+// must also be arena-allocated from the same arena. See the package
+// documentation section "Mixing Arena and Heap Values".
 func (v *Value) AppendArrayItems(a arena.Arena, right *Value) {
 	if v.t != TypeArray || right.t != TypeArray {
 		return
@@ -122,6 +131,8 @@ func DeduplicateObjectKeysRecursively(v *Value) {
 		return
 	}
 	o, _ := v.Object()
+	// Heap-allocated: maps cannot be placed on the arena. The allocation is
+	// bounded by the number of unique keys at each object level.
 	seen := make(map[string]struct{})
 	n := 0
 	for _, kv := range o.kvs {

--- a/util.go
+++ b/util.go
@@ -123,14 +123,18 @@ func DeduplicateObjectKeysRecursively(v *Value) {
 	}
 	o, _ := v.Object()
 	seen := make(map[string]struct{})
-	o.Visit(func(k []byte, v *Value) {
-		key := string(k)
-		if _, ok := seen[key]; ok {
-			o.Del(key)
-			return
-		} else {
-			seen[key] = struct{}{}
+	n := 0
+	for _, kv := range o.kvs {
+		if _, ok := seen[kv.k]; ok {
+			continue
 		}
-		DeduplicateObjectKeysRecursively(v)
-	})
+		seen[kv.k] = struct{}{}
+		o.kvs[n] = kv
+		n++
+		DeduplicateObjectKeysRecursively(kv.v)
+	}
+	for i := n; i < len(o.kvs); i++ {
+		o.kvs[i] = nil // clear trailing slots for GC
+	}
+	o.kvs = o.kvs[:n]
 }

--- a/util.go
+++ b/util.go
@@ -36,10 +36,15 @@ func startEndString(s string) string {
 	return start + "..." + end
 }
 
+// NullValue is a heap-allocated JSON null singleton. It is safe to use from
+// any context (heap or arena) since it is a package-level global that is always
+// reachable by the GC.
 var (
 	NullValue = MustParse(`null`)
 )
 
+// AppendToArray appends value to the end of array. Does nothing if array is
+// not of TypeArray. The arena a is used to grow the array's backing slice.
 func AppendToArray(a arena.Arena, array, value *Value) {
 	if array.Type() != TypeArray {
 		return
@@ -48,6 +53,12 @@ func AppendToArray(a arena.Arena, array, value *Value) {
 	array.SetArrayItem(a, len(items), value)
 }
 
+// SetValue sets value at the nested key path within v. Intermediate object
+// nodes are created on the arena as needed when they don't exist. The path
+// must have at least one element.
+//
+// Object keys created along the path are copied onto the arena when a is
+// non-nil, ensuring GC safety.
 func SetValue(a arena.Arena, v *Value, value *Value, path ...string) {
 	for i := 0; i < len(path)-1; i++ {
 		parent := v
@@ -61,12 +72,15 @@ func SetValue(a arena.Arena, v *Value, value *Value, path ...string) {
 	v.Set(a, path[len(path)-1], value)
 }
 
+// SetNull sets a null value at the nested key path within v. The null Value is
+// allocated on the arena when a is non-nil. See [SetValue] for path behavior.
 func SetNull(a arena.Arena, v *Value, path ...string) {
 	null := arena.Allocate[Value](a)
 	null.t = TypeNull
 	SetValue(a, v, null, path...)
 }
 
+// ValueIsNonNull reports whether v is non-nil and not TypeNull.
 func ValueIsNonNull(v *Value) bool {
 	if v == nil {
 		return false
@@ -77,6 +91,9 @@ func ValueIsNonNull(v *Value) bool {
 	return true
 }
 
+// AppendArrayItems appends all elements from right into v. Both v and right
+// must be TypeArray; does nothing otherwise. The arena a is used to grow v's
+// backing slice.
 func (v *Value) AppendArrayItems(a arena.Arena, right *Value) {
 	if v.t != TypeArray || right.t != TypeArray {
 		return
@@ -86,10 +103,14 @@ func (v *Value) AppendArrayItems(a arena.Arena, right *Value) {
 	}
 }
 
+// ValueIsNull reports whether v is nil or TypeNull.
 func ValueIsNull(v *Value) bool {
 	return !ValueIsNonNull(v)
 }
 
+// DeduplicateObjectKeysRecursively removes duplicate object keys from v and
+// all nested objects and arrays, keeping the first occurrence of each key.
+// This modifies v in place and does not require an arena.
 func DeduplicateObjectKeysRecursively(v *Value) {
 	if v.Type() == TypeArray {
 		a := v.GetArray()

--- a/util.go
+++ b/util.go
@@ -129,7 +129,7 @@ func DeepCopy(a arena.Arena, v *Value) *Value {
 				cp.a[i] = DeepCopy(a, item)
 			}
 		}
-	// TypeTrue, TypeFalse, TypeNull: only t is needed, already set above.
+	// TypeTrue, TypeFalse, TypeNull need no extra work: cp.t = v.t (line 119) is sufficient.
 	}
 	return cp
 }

--- a/util_test.go
+++ b/util_test.go
@@ -67,3 +67,40 @@ func TestAppendToArray(t *testing.T) {
 	out := a.MarshalTo(nil)
 	require.Equal(t, `[1,2,3]`, string(out))
 }
+
+func TestAppendToArrayNonArray(t *testing.T) {
+	v := MustParse(`"not an array"`)
+	AppendToArray(nil, v, MustParse(`1`))
+	require.Equal(t, TypeString, v.Type())
+}
+
+func TestValueIsNonNullNil(t *testing.T) {
+	require.False(t, ValueIsNonNull(nil))
+}
+
+func TestAppendArrayItemsNonArray(t *testing.T) {
+	left := MustParse(`"not array"`)
+	right := MustParse(`[1,2]`)
+	left.AppendArrayItems(nil, right)
+	require.Equal(t, TypeString, left.Type())
+
+	left2 := MustParse(`[1,2]`)
+	right2 := MustParse(`"not array"`)
+	left2.AppendArrayItems(nil, right2)
+	require.Equal(t, 2, len(left2.GetArray()))
+}
+
+func TestDeduplicateObjectKeysRecursivelyArray(t *testing.T) {
+	v := MustParse(`[{"a":1,"a":2},{"b":1}]`)
+	DeduplicateObjectKeysRecursively(v)
+	arr := v.GetArray()
+	require.Equal(t, 1, arr[0].GetObject().Len())
+}
+
+func TestStringValueBytesNilArena(t *testing.T) {
+	b := []byte("hello")
+	v := StringValueBytes(nil, b)
+	sb, err := v.StringBytes()
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(sb))
+}

--- a/util_test.go
+++ b/util_test.go
@@ -44,26 +44,26 @@ func TestGetArray(t *testing.T) {
 
 func TestSetNull(t *testing.T) {
 	a := MustParse(`{"name":"Jens"}`)
-	SetNull(a, "name")
+	SetNull(nil, a, "name")
 	out := a.MarshalTo(nil)
 	require.Equal(t, `{"name":null}`, string(out))
 
 	b := MustParse(`{"person":{"name":"Jens"}}`)
-	SetNull(b, "person", "name")
+	SetNull(nil, b, "person", "name")
 	out = b.MarshalTo(nil)
 	require.Equal(t, `{"person":{"name":null}}`, string(out))
 }
 
 func TestSetWithNonExistingPath(t *testing.T) {
 	a := MustParse(`{}`)
-	SetValue(a, MustParse(`1`), "a", "b")
+	SetValue(nil, a, MustParse(`1`), "a", "b")
 	out := a.MarshalTo(nil)
 	require.Equal(t, `{"a":{"b":1}}`, string(out))
 }
 
 func TestAppendToArray(t *testing.T) {
 	a := MustParse(`[1,2]`)
-	AppendToArray(a, MustParse(`3`))
+	AppendToArray(nil, a, MustParse(`3`))
 	out := a.MarshalTo(nil)
 	require.Equal(t, `[1,2,3]`, string(out))
 }

--- a/util_test.go
+++ b/util_test.go
@@ -97,6 +97,14 @@ func TestDeduplicateObjectKeysRecursivelyArray(t *testing.T) {
 	require.Equal(t, 1, arr[0].GetObject().Len())
 }
 
+func TestDeduplicateObjectKeysRecursivelyTripleDuplicate(t *testing.T) {
+	v := MustParse(`{"a":1,"a":2,"a":3}`)
+	DeduplicateObjectKeysRecursively(v)
+	o := v.GetObject()
+	require.Equal(t, 1, o.Len())
+	require.Equal(t, "1", o.Get("a").String())
+}
+
 func TestStringValueBytesNilArena(t *testing.T) {
 	b := []byte("hello")
 	v := StringValueBytes(nil, b)

--- a/validate.go
+++ b/validate.go
@@ -207,9 +207,6 @@ func validateString(s string) (string, string, error) {
 			return rs, tail, nil
 		}
 		n++
-		if n >= len(rs) {
-			return rs, tail, fmt.Errorf("BUG: parseRawString returned invalid string with trailing backslash: %q", rs)
-		}
 		ch := rs[n]
 		rs = rs[n+1:]
 		switch ch {

--- a/values.go
+++ b/values.go
@@ -16,7 +16,13 @@ func StringValue(a arena.Arena, s string) *Value {
 func StringValueBytes(a arena.Arena, b []byte) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeString
-	v.s = b2s(b)
+	if a != nil {
+		ab := arena.AllocateSlice[byte](a, len(b), len(b))
+		copy(ab, b)
+		v.s = b2s(ab)
+	} else {
+		v.s = b2s(b)
+	}
 	return v
 }
 

--- a/values.go
+++ b/values.go
@@ -6,6 +6,14 @@ import (
 	"github.com/wundergraph/go-arena"
 )
 
+// StringValue creates a JSON string Value containing s.
+//
+// When a is non-nil, both the Value struct and the string's backing bytes are
+// allocated on the arena (the string is copied). The caller may drop references
+// to s immediately.
+//
+// When a is nil, the Value is heap-allocated and references s directly. The
+// caller must keep s reachable for the lifetime of the returned Value.
 func StringValue(a arena.Arena, s string) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeString
@@ -13,6 +21,14 @@ func StringValue(a arena.Arena, s string) *Value {
 	return v
 }
 
+// StringValueBytes creates a JSON string Value from a byte slice.
+//
+// When a is non-nil, both the Value struct and the bytes are copied onto the
+// arena. The caller may reuse or discard b immediately.
+//
+// When a is nil, the Value is heap-allocated and references b's underlying
+// memory directly via zero-copy conversion. The caller must not modify b and
+// must keep it reachable for the lifetime of the returned Value.
 func StringValueBytes(a arena.Arena, b []byte) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeString
@@ -26,6 +42,11 @@ func StringValueBytes(a arena.Arena, b []byte) *Value {
 	return v
 }
 
+// IntValue creates a JSON number Value from an int.
+//
+// When a is non-nil, both the Value struct and the number's string
+// representation are allocated on the arena.
+// When a is nil, the Value is heap-allocated normally.
 func IntValue(a arena.Arena, i int) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeNumber
@@ -33,6 +54,11 @@ func IntValue(a arena.Arena, i int) *Value {
 	return v
 }
 
+// FloatValue creates a JSON number Value from a float64.
+//
+// When a is non-nil, both the Value struct and the number's string
+// representation are allocated on the arena.
+// When a is nil, the Value is heap-allocated normally.
 func FloatValue(a arena.Arena, f float64) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeNumber
@@ -40,6 +66,14 @@ func FloatValue(a arena.Arena, f float64) *Value {
 	return v
 }
 
+// NumberValue creates a JSON number Value from a raw numeric string.
+//
+// The string s must be a valid JSON number (e.g. "123", "3.14", "1e10").
+// No validation is performed.
+//
+// When a is non-nil, both the Value struct and the string's backing bytes are
+// allocated on the arena (the string is copied).
+// When a is nil, the Value is heap-allocated and references s directly.
 func NumberValue(a arena.Arena, s string) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeNumber
@@ -47,24 +81,44 @@ func NumberValue(a arena.Arena, s string) *Value {
 	return v
 }
 
+// TrueValue creates a JSON true Value.
+//
+// When a is non-nil, the Value struct is allocated on the arena.
+// When a is nil, it is heap-allocated.
 func TrueValue(a arena.Arena) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeTrue
 	return v
 }
 
+// FalseValue creates a JSON false Value.
+//
+// When a is non-nil, the Value struct is allocated on the arena.
+// When a is nil, it is heap-allocated.
 func FalseValue(a arena.Arena) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeFalse
 	return v
 }
 
+// ObjectValue creates an empty JSON object Value.
+//
+// Use [Object.Set] or [Value.Set] to add entries. Object keys and entry
+// backing slices are allocated on the arena when a is non-nil.
+//
+// When a is nil, the Value is heap-allocated.
 func ObjectValue(a arena.Arena) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeObject
 	return v
 }
 
+// ArrayValue creates an empty JSON array Value.
+//
+// Use [Value.SetArrayItem] or [AppendToArray] to add elements. The array's
+// backing slice is grown on the arena when a is non-nil.
+//
+// When a is nil, the Value is heap-allocated.
 func ArrayValue(a arena.Arena) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeArray

--- a/values.go
+++ b/values.go
@@ -1,7 +1,7 @@
 package astjson
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/wundergraph/go-arena"
 )
@@ -9,7 +9,7 @@ import (
 func StringValue(a arena.Arena, s string) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeString
-	v.s = s
+	v.s = arenaString(a, s)
 	return v
 }
 
@@ -23,21 +23,21 @@ func StringValueBytes(a arena.Arena, b []byte) *Value {
 func IntValue(a arena.Arena, i int) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeNumber
-	v.s = fmt.Sprintf("%d", i)
+	v.s = arenaString(a, strconv.Itoa(i))
 	return v
 }
 
 func FloatValue(a arena.Arena, f float64) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeNumber
-	v.s = fmt.Sprintf("%g", f)
+	v.s = arenaString(a, strconv.FormatFloat(f, 'g', -1, 64))
 	return v
 }
 
 func NumberValue(a arena.Arena, s string) *Value {
 	v := arena.Allocate[Value](a)
 	v.t = TypeNumber
-	v.s = s
+	v.s = arenaString(a, s)
 	return v
 }
 


### PR DESCRIPTION
Fixes use-after-free bugs where arena-allocated `Value` structs held references to heap strings that the GC could collect. All string data is now copied onto the arena via a new `arenaString()` helper, object keys are eagerly unescaped at parse time so results live on the arena, and array backing storage uses `arena.SliceAppend`. Adds 18 comprehensive GC safety tests (`arena_gc_test.go`) covering all API surfaces under aggressive GC pressure with the race detector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Arena-mode parsing and arena-aware value constructors plus a merge-with-path helper.

* **Tests**
  * Large GC-stress test suite validating parsing, mutations, merges, marshal/round-trips and many edge cases under aggressive GC.

* **Refactor**
  * Core ops rewritten for arena-backed allocation; keys pre-unescaped and lookup simplified; numeric/path helpers streamlined.

* **Breaking Changes**
  * Several public APIs now accept a leading arena/parent parameter; merge null-handling and numeric getter semantics changed.

* **Chores**
  * CI/toolchain bumped; README and docs expanded with arena guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->